### PR TITLE
fix: move focus btn to top right corner of predicate node in explore mode

### DIFF
--- a/src/components/Tree/Node/TableNode.tsx
+++ b/src/components/Tree/Node/TableNode.tsx
@@ -98,7 +98,7 @@ export default function TableNode({
                     <button
                         type="button"
                         className="custom-node-btn-corner-base custom-node-btn-corner-explore"
-                        style={{ top: -NORMAL_HEIGHT, left: node.width/2 - 10, ...(greyedButtonStyle(node) as React.CSSProperties) }}
+                        style={{ top: -NORMAL_HEIGHT, left: node.width - 10, ...(greyedButtonStyle(node) as React.CSSProperties) }}
                         onClick={() => {
                             if (focusClicked === node) {
                                 setFocusClicked(null)


### PR DESCRIPTION
closes https://github.com/Afshin-Zanganeh/nev/issues/1

<img width="570" height="604" alt="Screenshot 2026-01-31 at 11 03 45 PM" src="https://github.com/user-attachments/assets/f5985c8f-5bae-4263-9385-06f109465ad0" />