### PR TITLE
fix: make tables in bottom view fit content and left align

### DIFF
--- a/src/components/Scene/TableDialogPanel.tsx
+++ b/src/components/Scene/TableDialogPanel.tsx
@@ -280,7 +280,7 @@ function SingleTablePanel({
                     {node.isOutdated && <span style={{ color: "#d32f2f", marginLeft: 8 }}>(outdated)</span>}
                 </span>
             </Tooltip>
-            <div style={{ flex: "1 1 auto", maxHeight: 320, overflowY: "auto", marginBottom: 0 }}>
+            <div style={{ width: "fit-content", maxHeight: 320, overflowY: "auto", marginBottom: 0 }}>
                 <DataGrid
                     rows={pagedRows}
                     columns={columns}


### PR DESCRIPTION
closes https://github.com/Afshin-Zanganeh/nev/issues/2

before:
<img width="1728" height="290" alt="Screenshot 2026-02-01 at 12 18 37 AM" src="https://github.com/user-attachments/assets/3fa011b4-28a8-476a-b51a-e24ba16adc55" />

after:
<img width="1724" height="291" alt="Screenshot 2026-02-01 at 12 17 46 AM" src="https://github.com/user-attachments/assets/c17ffdf8-1f60-4167-9280-b7b2b7528286" />
