### PR TITLE
feat: add jump to root and deepest leaf navigation buttons

### DIFF
--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -7,11 +7,12 @@ import './../../assets/index.css'
 import SidePanel from "./SidePanel";
 import TableDialog from "./TableDialog";
 import type { Rule, TableEntriesForTreeNodesQuery, TableEntriesForTreeNodesResponse, TableEntryResponse, TreeForTableQuery, TreeForTableResponse } from "../../types/types";
-import { FaRedo, FaUndo, FaPenSquare, FaLock } from "react-icons/fa";
+import { FaRedo, FaUndo, FaPenSquare, FaLock, FaArrowUp, FaArrowDown } from "react-icons/fa";
 import TableDialogPanel from "./TableDialogPanel";
 import { HIGHLIGHTING_COLORS } from "../../types/constants";
 import EditQueryDialog from "./EditQueryDialog";
 import { StringFormatter } from "../../util/StringFormatter";
+import { findDeepestLeaf } from "../../util/findDeepestLeaf";
 import TextField from '@mui/material/TextField';
 import { ToggleButton, ToggleButtonGroup }  from "@mui/material";
 
@@ -290,6 +291,15 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
     sendType1Message(row, predicate);
   };
 
+  const handleJumpToRoot = () => {
+    setPanToNodeId({ node: rootNode, center: true });
+  };
+
+  const handleJumpToLeaf = () => {
+    const leaf = findDeepestLeaf(rootNode);
+    setPanToNodeId({ node: leaf, center: true });
+  };
+
   // Handle clicking a node in the tree (isExpanded)
   const handleNodeClick = (node: TreeNodeData) => {
     dataManager.changeNodeLayout(node, node.isExpanded);
@@ -423,7 +433,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
   return (
     <div style={{ position: "relative" }}>
       {/* Top right action buttons */}
-      <div style={{ position: "absolute", top: 16, right: 16, zIndex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ position: "absolute", top: 16, right: 16, zIndex: 1, display: "flex", flexDirection: "column", gap: 8, backgroundColor: "white", padding: 16, borderRadius: 8, boxShadow: "0 2px 8px rgba(0, 0, 0, 0.1)" }}>
         <div style={{textAlign:"center"}}>
         <ToggleButtonGroup
           size="small"
@@ -560,6 +570,31 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
             />
           </Box>
         </Tooltip>
+
+        <Box sx={{ display: "flex", gap: 1.5, marginTop: 2 }}>
+          <Tooltip title="Jump to the root node of the tree!" placement="left" enterDelay={500}>
+            <Button
+              variant="contained"
+              size="small"
+              fullWidth
+              startIcon={<FaArrowUp />}
+              onClick={handleJumpToRoot}
+            >
+              Root
+            </Button>
+          </Tooltip>
+          <Tooltip title="Jump to the deepest leaf node of the tree!" placement="left" enterDelay={500}>
+            <Button
+              variant="contained"
+              size="small"
+              fullWidth
+              startIcon={<FaArrowDown />}
+              onClick={handleJumpToLeaf}
+            >
+              Leaf
+            </Button>
+          </Tooltip>
+        </Box>
       </div>
 
       {/* Snackbar for notifications */}

--- a/src/util/findDeepestLeaf.ts
+++ b/src/util/findDeepestLeaf.ts
@@ -1,0 +1,25 @@
+import { TreeNodeData } from "../data/TreeNodeData";
+
+type DeepestResult = { leaf: TreeNodeData; depth: number };
+
+const findDeepest = (current: TreeNodeData, depth: number): DeepestResult => {
+  const currentChildren = current.getChildren();
+  if (currentChildren.length === 0) {
+    return { leaf: current, depth };
+  }
+
+  let result: DeepestResult = { leaf: current, depth };
+  for (const child of currentChildren) {
+    const found = findDeepest(child, depth + 1);
+    if (found.depth > result.depth) {
+      result = found;
+    }
+  }
+
+  return result;
+};
+
+export const findDeepestLeaf = (node: TreeNodeData): TreeNodeData => {
+  const result = findDeepest(node, 0);
+  return result.leaf;
+};


### PR DESCRIPTION
added jump to root and lowermost leaf buttons to right sidebar part:

<img width="1036" height="771" alt="Screenshot 2026-02-08 at 12 25 11 AM" src="https://github.com/user-attachments/assets/745e4f9e-61da-4e76-9794-69372638cd2d" />

I also added tooltip for guide.

I added a white background and shadow to the right section because it had overlap and conflict with rendered tree sometimes when it didn't have white background and it was not suitable in my opinion.

closes https://github.com/Afshin-Zanganeh/nev/issues/8