### PR TITLE
feat: show total execution time per node without expanding them

### DIFF
--- a/src/assets/NodeBox.css
+++ b/src/assets/NodeBox.css
@@ -46,6 +46,22 @@
   min-height: 36px;
 }
 
+.table-node-box__header {
+  flex-direction: column;
+}
+
+.table-node-box__name {
+  white-space: nowrap;
+}
+
+.table-node-box__execution-time {
+  color: #4f6259;
+  font-size: 0.72em;
+  font-weight: normal;
+  line-height: 18px;
+  white-space: nowrap;
+}
+
 /* Body */
 .table-node-box__body {
   padding: 4px 0;

--- a/src/assets/NodeBox.css
+++ b/src/assets/NodeBox.css
@@ -12,6 +12,8 @@
 }
 .table-node-box {
   border-radius: 8px;
+  overflow: visible;
+  position: relative;
 }
 .table-node-box--highlighted {
   outline: 3px solid #ffb300;
@@ -54,12 +56,17 @@
   white-space: nowrap;
 }
 
-.table-node-box__execution-time {
-  color: #4f6259;
-  font-size: 0.72em;
-  font-weight: normal;
-  line-height: 18px;
-  white-space: nowrap;
+.table-node-box__execution-time-stripe {
+  position: absolute;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  height: 6px;
+  border-bottom-left-radius: 7px;
+  border-bottom-right-radius: 7px;
+  z-index: 4;
+  pointer-events: none;
+  transition: background-color 0.18s ease;
 }
 
 /* Body */

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Tree from "../Tree/Tree";
-import { Snackbar, Tooltip, Button, Slider, Box, Input, Alert } from "@mui/material";
+import { Snackbar, Tooltip, Button, Slider, Box, Input, Alert, FormControlLabel, Switch } from "@mui/material";
 import { DataManager } from "./DataManager";
 import { RuleNodeData, TableNodeData, TreeNodeData } from "../../data/TreeNodeData";
 import './../../assets/index.css'
@@ -89,6 +89,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
 
   const [editQueryOpen, setEditQueryOpen] = useState(false);
   const [maxLength, setMaxLength] = useState(StringFormatter.maxLengthSlider);
+  const [showNodeExecutionTimes, setShowNodeExecutionTimes] = useState(false);
 
   useEffect(() => {
     setMaxLength(StringFormatter.maxLengthSlider);
@@ -571,6 +572,20 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
           </Box>
         </Tooltip>
 
+        <Tooltip title="Show the total reasoning time directly on every table node." placement="left" enterDelay={500}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showNodeExecutionTimes}
+                onChange={(_, checked) => setShowNodeExecutionTimes(checked)}
+                size="small"
+              />
+            }
+            label="Show total time per node"
+            sx={{ marginLeft: 0 }}
+          />
+        </Tooltip>
+
         <Box sx={{ display: "flex", gap: 1.5, marginTop: 2 }}>
           <Tooltip title="Jump to the root node of the tree!" placement="left" enterDelay={500}>
             <Button
@@ -644,6 +659,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
       <Tree
         data={rootNode}
         mode={mode}
+        showNodeExecutionTimes={showNodeExecutionTimes}
         giveRemoveAbovePreview={handleRemoveAbovePreview}
         giveRemoveBelowPreview={handleRemoveEdgePreview}
         panToNodeId={panToNodeId}

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -579,18 +579,27 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
           </Box>
         </Tooltip>
 
-        <Tooltip title="Show the total reasoning time directly on every table node." placement="left" enterDelay={500}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={showNodeExecutionTimes}
-                onChange={(_, checked) => setShowNodeExecutionTimes(checked)}
-                size="small"
-              />
-            }
-            label="Show total time per node"
-            sx={{ marginLeft: 0 }} />
-          </Tooltip>
+        <Tooltip
+          title="Show or hide the bottom color strip that compares each node's reasoning time."
+          placement="left"
+          enterDelay={2000}
+          enterNextDelay={2000}
+        >
+          <span>
+            <FormControlLabel
+              sx={{ margin: 0, justifyContent: "space-between", fontSize: 14, width: "100%" }}
+              label="Show time strips"
+              labelPlacement="start"
+              control={
+                <Switch
+                  checked={showNodeExecutionTimes}
+                  onChange={(_, checked) => setShowNodeExecutionTimes(checked)}
+                  size="small"
+                />
+              }
+            />
+          </span>
+        </Tooltip>
         <Tooltip
           title="Toggle logic variable text colors."
           placement="left"

--- a/src/components/Tree/CustomLink.tsx
+++ b/src/components/Tree/CustomLink.tsx
@@ -1,16 +1,19 @@
 import '../../assets/Link.css'
-import type { PositionedTableNodeData } from "../../data/TreeNodeData";
+import { TableNodeData, type PositionedTableNodeData } from "../../data/TreeNodeData";
 import { EXTENDED_HEIGHT, NORMAL_HEIGHT } from "../../types/constants";
 
 type LinkProps = {
   source: PositionedTableNodeData;
   target: PositionedTableNodeData;
+  showNodeExecutionTimes: boolean;
 };
 
-export default function CustomLink({ source, target }: Readonly<LinkProps>) {
+export default function CustomLink({ source, target, showNodeExecutionTimes }: Readonly<LinkProps>) {
+  const compactExecutionTimeOffset =
+    showNodeExecutionTimes && source.data instanceof TableNodeData && !source.data.isExpanded ? 18 : 0;
   const sourcePoint = [
     source.x,
-    source.y + (source.data.isExpanded ? EXTENDED_HEIGHT + 4: NORMAL_HEIGHT * 3 - 9)
+    source.y + (source.data.isExpanded ? EXTENDED_HEIGHT + 4 : NORMAL_HEIGHT * 3 - 9 + compactExecutionTimeOffset)
   ]
   
   const targetPoint = [

--- a/src/components/Tree/CustomLink.tsx
+++ b/src/components/Tree/CustomLink.tsx
@@ -1,19 +1,16 @@
 import '../../assets/Link.css'
-import { TableNodeData, type PositionedTableNodeData } from "../../data/TreeNodeData";
+import type { PositionedTableNodeData } from "../../data/TreeNodeData";
 import { EXTENDED_HEIGHT, NORMAL_HEIGHT } from "../../types/constants";
 
 type LinkProps = {
   source: PositionedTableNodeData;
   target: PositionedTableNodeData;
-  showNodeExecutionTimes: boolean;
 };
 
-export default function CustomLink({ source, target, showNodeExecutionTimes }: Readonly<LinkProps>) {
-  const compactExecutionTimeOffset =
-    showNodeExecutionTimes && source.data instanceof TableNodeData && !source.data.isExpanded ? 18 : 0;
+export default function CustomLink({ source, target }: Readonly<LinkProps>) {
   const sourcePoint = [
     source.x,
-    source.y + (source.data.isExpanded ? EXTENDED_HEIGHT + 4 : NORMAL_HEIGHT * 3 - 9 + compactExecutionTimeOffset)
+    source.y + (source.data.isExpanded ? EXTENDED_HEIGHT + 4 : NORMAL_HEIGHT * 3 - 9)
   ]
   
   const targetPoint = [

--- a/src/components/Tree/Node/TableNode.tsx
+++ b/src/components/Tree/Node/TableNode.tsx
@@ -15,6 +15,7 @@ import PositionDialog from './PositionDialog'
 type NodeProps = {
     node: TableNodeData,
     mode: 'explore' | 'query';
+    showExecutionTime: boolean;
     focusClicked: TreeNodeData | null;
     setFocusClicked: (node: TreeNodeData | null) => void;
     onAddAboveButtonClick: (ruleId: Rule, index: number) => void;
@@ -37,6 +38,7 @@ type NodeProps = {
 export default function TableNode({
     node,
     mode,
+    showExecutionTime,
     focusClicked,
     setFocusClicked,
     onAddAboveButtonClick,
@@ -88,6 +90,7 @@ export default function TableNode({
             <TableNodeBox
                 node={node}
                 mode={mode}
+                showExecutionTime={showExecutionTime}
                 isHovered={isHovered}
                 onNodeClicked={onNodeClicked}
                 onRowClicked={onRowClicked}

--- a/src/components/Tree/Node/TableNode.tsx
+++ b/src/components/Tree/Node/TableNode.tsx
@@ -8,7 +8,7 @@ import { TbFocus2 } from 'react-icons/tb'
 import { greyedButtonStyle, NORMAL_HEIGHT } from '../../../types/constants'
 import { FaCodeFork, FaCodePullRequest, FaScissors } from 'react-icons/fa6'
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io'
-import type { Rule, TableEntryResponse, Timeouts } from '../../../types/types'
+import type { ExecutionTimeRange, Rule, TableEntryResponse, Timeouts } from '../../../types/types'
 import PositionDialog from './PositionDialog'
 
 
@@ -16,6 +16,7 @@ type NodeProps = {
     node: TableNodeData,
     mode: 'explore' | 'query';
     showExecutionTime: boolean;
+    executionTimeRange: ExecutionTimeRange;
     focusClicked: TreeNodeData | null;
     setFocusClicked: (node: TreeNodeData | null) => void;
     onAddAboveButtonClick: (ruleId: Rule, index: number) => void;
@@ -39,6 +40,7 @@ export default function TableNode({
     node,
     mode,
     showExecutionTime,
+    executionTimeRange,
     focusClicked,
     setFocusClicked,
     onAddAboveButtonClick,
@@ -91,6 +93,7 @@ export default function TableNode({
                 node={node}
                 mode={mode}
                 showExecutionTime={showExecutionTime}
+                executionTimeRange={executionTimeRange}
                 isHovered={isHovered}
                 onNodeClicked={onNodeClicked}
                 onRowClicked={onRowClicked}

--- a/src/components/Tree/Node/TableNodeBox.tsx
+++ b/src/components/Tree/Node/TableNodeBox.tsx
@@ -12,6 +12,7 @@ import type { TableEntryResponse } from '../../../types/types'
 type NodeBoxProps = {
   node: TableNodeData
   mode: 'explore' | 'query';
+  showExecutionTime: boolean;
   isHovered?: boolean
   onNodeClicked: (node: TreeNodeData) => void;
   clicked?: boolean
@@ -29,9 +30,11 @@ type TableNodeDetailsProps = {
 function TableNodeHeader({
   node,
   onClick,
+  showExecutionTime,
 }: {
   readonly node: TableNodeData;
   readonly onClick: () => void;
+  readonly showExecutionTime: boolean;
 }) {
   const name = node.getName();
   const needsTooltip = StringFormatter.needsTruncation(name);
@@ -51,10 +54,15 @@ function TableNodeHeader({
       >
         {needsTooltip ? (
           <Tooltip title={unshortenedFormattedName} placement="top" enterDelay={800}>
-            <span style={{ whiteSpace: "nowrap"}}>&nbsp;{formattedName}&nbsp;</span>
+            <span className="table-node-box__name">&nbsp;{formattedName}&nbsp;</span>
           </Tooltip>
         ) : (
-          <span style={{ whiteSpace: "nowrap"}}>&nbsp;{formattedName}&nbsp;</span>
+          <span className="table-node-box__name">&nbsp;{formattedName}&nbsp;</span>
+        )}
+        {showExecutionTime && !node.isExpanded && node.executionTime !== undefined && (
+          <span className="table-node-box__execution-time">
+            Total time: {node.executionTime} ms
+          </span>
         )}
       </div>
     </Tooltip>
@@ -241,7 +249,7 @@ function TableNodeDetails({ node, mode, onRowClicked, onPopOutClicked }: Readonl
   );
 }
 
-export function TableNodeBox({ node, mode, isHovered, clicked, onNodeClicked, onRowClicked, onPopOutClicked }: Readonly<NodeBoxProps>) {
+export function TableNodeBox({ node, mode, showExecutionTime, isHovered, clicked, onNodeClicked, onRowClicked, onPopOutClicked }: Readonly<NodeBoxProps>) {
   const outlineColor = HIGHLIGHTING_COLORS[node.isHighlighted] || undefined;
 
   return (
@@ -266,6 +274,7 @@ export function TableNodeBox({ node, mode, isHovered, clicked, onNodeClicked, on
       {<>
         <TableNodeHeader
           node={node}
+          showExecutionTime={showExecutionTime}
           onClick={() => {
             node.isExpanded = !node.isExpanded;
             onNodeClicked(node);

--- a/src/components/Tree/Node/TableNodeBox.tsx
+++ b/src/components/Tree/Node/TableNodeBox.tsx
@@ -7,13 +7,15 @@ import { IconButton } from '@mui/material'
 import StringFormatter from '../../../util/StringFormatter'
 import { FaMagnifyingGlass, FaTable } from 'react-icons/fa6'
 import { HIGHLIGHTING_COLORS } from '../../../types/constants'
-import type { TableEntryResponse } from '../../../types/types'
+import type { ExecutionTimeRange, TableEntryResponse } from '../../../types/types'
+import { getExecutionTimeStripeColor } from '../../../util/executionTimeColors'
 import ColoredLogicText from '../../ColoredLogicText'
 
 type NodeBoxProps = {
   node: TableNodeData
   mode: 'explore' | 'query';
   showExecutionTime: boolean;
+  executionTimeRange: ExecutionTimeRange;
   isHovered?: boolean
   onNodeClicked: (node: TreeNodeData) => void;
   clicked?: boolean
@@ -31,11 +33,9 @@ type TableNodeDetailsProps = {
 function TableNodeHeader({
   node,
   onClick,
-  showExecutionTime,
 }: {
   readonly node: TableNodeData;
   readonly onClick: () => void;
-  readonly showExecutionTime: boolean;
 }) {
   const name = node.getName();
   const needsTooltip = StringFormatter.needsTruncation(name);
@@ -62,11 +62,6 @@ function TableNodeHeader({
         ) : (
           <span className="table-node-box__name" style={{ whiteSpace: "nowrap" }}>
             &nbsp;<ColoredLogicText text={formattedName} />&nbsp;
-          </span>
-        )}
-        {showExecutionTime && !node.isExpanded && node.executionTime !== undefined && (
-          <span className="table-node-box__execution-time">
-            Total time: {node.executionTime} ms
           </span>
         )}
       </div>
@@ -260,8 +255,11 @@ function TableNodeDetails({ node, mode, onRowClicked, onPopOutClicked }: Readonl
   );
 }
 
-export function TableNodeBox({ node, mode, showExecutionTime, isHovered, clicked, onNodeClicked, onRowClicked, onPopOutClicked }: Readonly<NodeBoxProps>) {
+export function TableNodeBox({ node, mode, showExecutionTime, executionTimeRange, isHovered, clicked, onNodeClicked, onRowClicked, onPopOutClicked }: Readonly<NodeBoxProps>) {
   const outlineColor = HIGHLIGHTING_COLORS[node.isHighlighted] || undefined;
+  const executionTimeStripeColor = Number.isFinite(node.executionTime)
+    ? getExecutionTimeStripeColor(node.executionTime, executionTimeRange)
+    : undefined;
 
   return (
     <div
@@ -285,7 +283,6 @@ export function TableNodeBox({ node, mode, showExecutionTime, isHovered, clicked
       {<>
         <TableNodeHeader
           node={node}
-          showExecutionTime={showExecutionTime}
           onClick={() => {
             node.isExpanded = !node.isExpanded;
             onNodeClicked(node);
@@ -294,6 +291,13 @@ export function TableNodeBox({ node, mode, showExecutionTime, isHovered, clicked
 
         {node.isExpanded && (
           <TableNodeDetails node={node} mode={mode} onRowClicked={onRowClicked} onPopOutClicked={onPopOutClicked} />
+        )}
+        {showExecutionTime && executionTimeStripeColor && (
+          <div
+            className="table-node-box__execution-time-stripe"
+            style={{ backgroundColor: executionTimeStripeColor }}
+            title={`Execution time: ${node.executionTime} ms`}
+          />
         )}
       </>}
     </div>

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -14,6 +14,7 @@ type PanToNode = { node: TreeNodeData, center?: boolean } | null;
 type TreeProps = {
   data: TableNodeData;
   mode: "explore" | "query";
+  showNodeExecutionTimes: boolean;
   treeVersion: number;
   panToNodeId?: PanToNode;
   setPanToNodeId?: (id: PanToNode) => void;
@@ -44,6 +45,7 @@ type TreeProps = {
 export default function Tree({
   data,
   mode,
+  showNodeExecutionTimes,
   width,
   height,
   panToNodeId,
@@ -81,7 +83,9 @@ export default function Tree({
 
     const layout = flextree({}).nodeSize((node: d3.HierarchyNode<unknown>) => [
       ((node.data as TableNodeData).width ?? 60) + 60,
-      ((node.data as TableNodeData).height ?? 120) + 100
+      ((node.data as TableNodeData).height ?? 120)
+        + (showNodeExecutionTimes && node.data instanceof TableNodeData && !(node.data as TableNodeData).isExpanded ? 18 : 0)
+        + 100
     ]);
 
     StringFormatter.getInstance().resetMaxLengthSlider(data);
@@ -92,7 +96,7 @@ export default function Tree({
     const maxX = Math.max(...nodes.map((n: { x: number }) => n.x ?? 0));
     const maxY = Math.max(...nodes.map((n: { y: number }) => n.y ?? 0));
     return { nodes, links, maxX, maxY };
-  }, [data, width, height, treeVersion, mode]);
+  }, [data, width, height, treeVersion, mode, showNodeExecutionTimes]);
 
   const isSingleRuleTree = useMemo(() => {
     let ruleCount = 0;
@@ -225,7 +229,12 @@ useEffect(() => {
         <g transform={transform.toString()}>
           {links
             .map((link: FlextreeLink, i: number) => (
-              <CustomLink key={i} source={link.source} target={link.target} />
+              <CustomLink
+                key={i}
+                source={link.source}
+                target={link.target}
+                showNodeExecutionTimes={showNodeExecutionTimes}
+              />
             ))}
 
           {nodes.map((node: PositionedTableNodeData, i: number) => (
@@ -233,6 +242,7 @@ useEffect(() => {
               key={i}
               node={node}
               mode={mode}
+              showNodeExecutionTimes={showNodeExecutionTimes}
               isSingleRuleTree={isSingleRuleTree}
               codingButtonClicked={codingButtonClicked}
               focusClicked={focusClicked}

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -83,9 +83,7 @@ export default function Tree({
 
     const layout = flextree({}).nodeSize((node: d3.HierarchyNode<unknown>) => [
       ((node.data as TableNodeData).width ?? 60) + 60,
-      ((node.data as TableNodeData).height ?? 120)
-        + (showNodeExecutionTimes && node.data instanceof TableNodeData && !(node.data as TableNodeData).isExpanded ? 18 : 0)
-        + 100
+      ((node.data as TableNodeData).height ?? 120) + 100
     ]);
 
     StringFormatter.getInstance().resetMaxLengthSlider(data);
@@ -96,7 +94,7 @@ export default function Tree({
     const maxX = Math.max(...nodes.map((n: { x: number }) => n.x ?? 0));
     const maxY = Math.max(...nodes.map((n: { y: number }) => n.y ?? 0));
     return { nodes, links, maxX, maxY };
-  }, [data, width, height, treeVersion, mode, showNodeExecutionTimes]);
+  }, [data, width, height, treeVersion, mode]);
 
   const isSingleRuleTree = useMemo(() => {
     let ruleCount = 0;
@@ -113,6 +111,57 @@ export default function Tree({
     }
     return ruleCount <= 1;
   }, [data, treeVersion]);
+
+  const executionTimeRange = (() => {
+    const executionTimes: number[] = [];
+    const stack: TreeNodeData[] = [data];
+
+    while (stack.length) {
+      const current = stack.pop();
+      if (!current) continue;
+
+      if (current instanceof TableNodeData && Number.isFinite(current.executionTime)) {
+        executionTimes.push(current.executionTime);
+      }
+
+      stack.push(...(current.getChildren?.() ?? []));
+    }
+
+    if (executionTimes.length === 0) return null;
+
+    const sortedScaledTimes = executionTimes
+      .map(time => Math.log1p(time))
+      .sort((a, b) => a - b);
+
+    const quantile = (values: number[], q: number) => {
+      if (values.length === 1) return values[0];
+
+      const position = (values.length - 1) * q;
+      const base = Math.floor(position);
+      const rest = position - base;
+      const nextValue = values[base + 1];
+
+      if (nextValue === undefined) return values[base];
+
+      return values[base] + rest * (nextValue - values[base]);
+    };
+
+    const scaledMin = sortedScaledTimes[0];
+    const scaledMax = sortedScaledTimes[sortedScaledTimes.length - 1];
+    const firstQuartile = quantile(sortedScaledTimes, 0.25);
+    const thirdQuartile = quantile(sortedScaledTimes, 0.75);
+    const interquartileRange = thirdQuartile - firstQuartile;
+    const robustUpper = interquartileRange === 0
+      ? scaledMax
+      : Math.min(scaledMax, thirdQuartile + interquartileRange * 1.5);
+
+    return {
+      min: Math.min(...executionTimes),
+      max: Math.max(...executionTimes),
+      scaleMin: scaledMin,
+      scaleMax: Math.max(scaledMin, robustUpper),
+    };
+  })();
 
   const padding = 100
   if (!width) width = 0;
@@ -233,7 +282,6 @@ useEffect(() => {
                 key={i}
                 source={link.source}
                 target={link.target}
-                showNodeExecutionTimes={showNodeExecutionTimes}
               />
             ))}
 
@@ -243,6 +291,7 @@ useEffect(() => {
               node={node}
               mode={mode}
               showNodeExecutionTimes={showNodeExecutionTimes}
+              executionTimeRange={executionTimeRange}
               isSingleRuleTree={isSingleRuleTree}
               codingButtonClicked={codingButtonClicked}
               focusClicked={focusClicked}

--- a/src/components/Tree/TreeNodeRenderer.tsx
+++ b/src/components/Tree/TreeNodeRenderer.tsx
@@ -1,6 +1,6 @@
 import { RuleNodeData, TableNodeData, TreeNodeData } from "../../data/TreeNodeData";
 import type { PositionedTableNodeData } from "../../data/TreeNodeData";
-import type { Rule, TableEntryResponse } from "../../types/types";
+import type { ExecutionTimeRange, Rule, TableEntryResponse } from "../../types/types";
 import RuleNode from "./Node/RuleNode";
 import TableNode from "./Node/TableNode";
 
@@ -8,6 +8,7 @@ type TreeNodeRendererProps = {
   node: PositionedTableNodeData;
   mode: "explore" | "query";
   showNodeExecutionTimes: boolean;
+  executionTimeRange: ExecutionTimeRange;
   isSingleRuleTree: boolean;
   focusClicked: TreeNodeData | null;
   setFocusClicked: (node: TreeNodeData | null) => void;
@@ -34,6 +35,7 @@ export default function TreeNodeRenderer({
   node,
   mode,
   showNodeExecutionTimes,
+  executionTimeRange,
   isSingleRuleTree,
   focusClicked,
   setFocusClicked,
@@ -69,6 +71,7 @@ export default function TreeNodeRenderer({
             node={node.data}
             mode={mode}
             showExecutionTime={showNodeExecutionTimes}
+            executionTimeRange={executionTimeRange}
             setFocusClicked={setFocusClicked}
             focusClicked={focusClicked}
             onRowClicked={onRowClicked}

--- a/src/components/Tree/TreeNodeRenderer.tsx
+++ b/src/components/Tree/TreeNodeRenderer.tsx
@@ -7,6 +7,7 @@ import TableNode from "./Node/TableNode";
 type TreeNodeRendererProps = {
   node: PositionedTableNodeData;
   mode: "explore" | "query";
+  showNodeExecutionTimes: boolean;
   isSingleRuleTree: boolean;
   focusClicked: TreeNodeData | null;
   setFocusClicked: (node: TreeNodeData | null) => void;
@@ -32,6 +33,7 @@ type TreeNodeRendererProps = {
 export default function TreeNodeRenderer({
   node,
   mode,
+  showNodeExecutionTimes,
   isSingleRuleTree,
   focusClicked,
   setFocusClicked,
@@ -66,6 +68,7 @@ export default function TreeNodeRenderer({
         <TableNode
             node={node.data}
             mode={mode}
+            showExecutionTime={showNodeExecutionTimes}
             setFocusClicked={setFocusClicked}
             focusClicked={focusClicked}
             onRowClicked={onRowClicked}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -7,6 +7,13 @@ export type Timeouts = {
     [key: string]: number;
 };
 
+export type ExecutionTimeRange = {
+  min: number;
+  max: number;
+  scaleMin: number;
+  scaleMax: number;
+} | null;
+
 export type UndoRedoStateRule = {
   rule: Rule;
   isCollapsed?: boolean;

--- a/src/util/executionTimeColors.ts
+++ b/src/util/executionTimeColors.ts
@@ -1,0 +1,48 @@
+import type { ExecutionTimeRange } from "../types/types";
+
+type RgbColor = readonly [number, number, number];
+
+const FAST_COLOR: RgbColor = [5, 150, 105];
+const MIDDLE_COLOR: RgbColor = [234, 179, 8];
+const SLOW_COLOR: RgbColor = [220, 38, 38];
+const MIDDLE_RATIO = 0.5;
+
+function clampRatio(value: number) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function getExecutionTimeRatio(executionTime: number, range: NonNullable<ExecutionTimeRange>) {
+  const span = range.scaleMax - range.scaleMin;
+  const scaledTime = Math.log1p(executionTime);
+
+  if (span === 0) return 0;
+
+  return clampRatio((scaledTime - range.scaleMin) / span);
+}
+
+function interpolateColor(from: RgbColor, to: RgbColor, ratio: number): RgbColor {
+  return from.map((channel, index) =>
+    Math.round(channel + (to[index] - channel) * ratio)
+  ) as unknown as RgbColor;
+}
+
+function getPaletteColor(ratio: number) {
+  if (ratio <= MIDDLE_RATIO) {
+    const greenToYellowRatio = ratio / MIDDLE_RATIO;
+    return interpolateColor(FAST_COLOR, MIDDLE_COLOR, greenToYellowRatio);
+  }
+
+  const yellowToRedRatio = (ratio - MIDDLE_RATIO) / (1 - MIDDLE_RATIO);
+  return interpolateColor(MIDDLE_COLOR, SLOW_COLOR, yellowToRedRatio);
+}
+
+function formatRgbColor([red, green, blue]: RgbColor) {
+  return `rgb(${red}, ${green}, ${blue})`;
+}
+
+export function getExecutionTimeStripeColor(executionTime: number, range: ExecutionTimeRange) {
+  if (!range) return undefined;
+
+  const ratio = getExecutionTimeRatio(executionTime, range);
+  return formatRgbColor(getPaletteColor(ratio));
+}


### PR DESCRIPTION
Adds a toggle in the sidebar to display each node’s total execution time without expanding it

screenshot:

<img width="1468" height="617" alt="Screenshot 2026-06-15 at 8 00 29 AM" src="https://github.com/user-attachments/assets/232c3c54-34b0-4818-9ed4-7430e1fe432c" />


I updated the design and now it is like this:

<img width="964" height="866" alt="Screenshot 2026-06-22 at 9 34 45 AM" src="https://github.com/user-attachments/assets/f0752217-d60a-4ca0-b181-e930b2e570dc" />


