### PR TITLE
fix: preserve expanded predicate nodes when focusing a fact

### DIFF
--- a/src/components/Scene/DataManager.ts
+++ b/src/components/Scene/DataManager.ts
@@ -74,6 +74,39 @@ export class DataManager {
         return tableNode;
     }
 
+    public preserveExpandedPredicateNodes(previousRoot: TableNodeData, nextRoot: TableNodeData) {
+        const expandedNodes = new Set<string>();
+        const previousNodes: TableNodeData[] = [previousRoot];
+        const nodes: TableNodeData[] = [nextRoot];
+
+        for (const node of previousNodes) {
+            if (node.isExpanded) {
+                expandedNodes.add(`${node.id.join(",")}:${node.getName()}`);
+            }
+
+            const ruleNode = node.getChildren()[0];
+            if (ruleNode) {
+                previousNodes.push(...ruleNode.getChildren().filter(
+                    (child): child is TableNodeData => child instanceof TableNodeData
+                ));
+            }
+        }
+
+        for (const node of nodes) {
+            if (expandedNodes.has(`${node.id.join(",")}:${node.getName()}`)) {
+                node.isExpanded = true;
+                this.changeNodeLayout(node, true);
+            }
+
+            const ruleNode = node.getChildren()[0];
+            if (ruleNode) {
+                nodes.push(...ruleNode.getChildren().filter(
+                    (child): child is TableNodeData => child instanceof TableNodeData
+                ));
+            }
+        }
+    }
+
     public loadUndoEntry(json: UndoRedoState, ruleParameters: string[] = [], ownId: number[] = []): TableNodeData {
         let parameters = ruleParameters;
         if (ruleParameters.length === 0 && json.childInformation) parameters = json.childInformation.rule.relevantHeadPredicate.parameters!

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -173,6 +173,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
       const tftr = message.payload as TreeForTableResponse;
       const node = dataManager.handleType1Response(tftr);
       node.isRootNode = true;
+      dataManager.preserveExpandedPredicateNodes(rootNode, node);
       const qs = tftr.tableEntries.entries.map(e => e.termTuple.join(","));
       setRootNode(node);
       setQueries(qs);


### PR DESCRIPTION
Preserve expanded predicate nodes when focusing on a root table fact by transferring expansion state to matching nodes in the refreshed tree.

screenshots:

before focusing:

<img width="1725" height="644" alt="Screenshot 2026-06-15 at 8 18 41 AM" src="https://github.com/user-attachments/assets/ed205278-9fd6-4b04-a516-e60ba17631cf" />


after focusing (query in the url has changed but the expansion state preserved):

<img width="1727" height="629" alt="Screenshot 2026-06-15 at 8 18 52 AM" src="https://github.com/user-attachments/assets/f2b08c75-002a-42f9-98d7-4db456429fb9" />
