### PR TITLE
feat: add logic variables colorization

### DIFF
--- a/src/components/ColoredLogicText.tsx
+++ b/src/components/ColoredLogicText.tsx
@@ -1,0 +1,91 @@
+import { useContext, type ReactNode } from 'react'
+import { LogicColorizationContext } from './logicColorization'
+
+type ColoredLogicTextProps = {
+  text: string
+  standaloneTerm?: boolean
+  colorIndex?: number
+}
+
+const TERM_PATTERN = /(\?[A-Za-z_][A-Za-z0-9_]*|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[A-Za-z_][A-Za-z0-9_]*|-?\d+(?:\.\d+)?)/g
+
+const TERM_COLORS = [
+  { text: '#a0006d', background: '#ffc4ea' },
+  { text: '#0756a3', background: '#b9dcff' },
+  { text: '#a13c00', background: '#ffd2ad' },
+  { text: '#b42318', background: '#ffc7c2' },
+  { text: '#5b21b6', background: '#dec9ff' },
+  { text: '#6f3f17', background: '#e7c8aa' },
+  { text: '#334155', background: '#d5dbe3' },
+] as const
+
+function colorForIndex(index: number) {
+  return TERM_COLORS[index % TERM_COLORS.length]
+}
+
+function isPredicateName(text: string, end: number) {
+  return text.slice(end).trimStart().startsWith('(')
+}
+
+function ColoredTerm({ term, colorIndex }: Readonly<{ term: string; colorIndex: number }>) {
+  const mode = useContext(LogicColorizationContext)
+  const color = colorForIndex(colorIndex)
+  return (
+    <span
+      style={{
+        color: color.text,
+        backgroundColor: mode === 'background' ? color.background : undefined,
+        borderRadius: mode === 'background' ? 3 : undefined,
+        boxShadow: mode === 'background' ? `0 0 0 2px ${color.background}` : undefined,
+      }}
+    >
+      {term}
+    </span>
+  )
+}
+
+export default function ColoredLogicText({
+  text,
+  standaloneTerm = false,
+  colorIndex = 0,
+}: Readonly<ColoredLogicTextProps>) {
+  if (standaloneTerm) {
+    return <ColoredTerm term={text} colorIndex={colorIndex} />
+  }
+
+  const parts: ReactNode[] = []
+  const argumentIndexes: number[] = []
+  let cursor = 0
+
+  for (const match of text.matchAll(TERM_PATTERN)) {
+    const start = match.index
+    const end = start + match[0].length
+    const precedingText = text.slice(cursor, start)
+
+    parts.push(precedingText)
+    for (const character of precedingText) {
+      if (character === '(') {
+        argumentIndexes.push(0)
+      } else if (character === ',' && argumentIndexes.length > 0) {
+        argumentIndexes[argumentIndexes.length - 1] += 1
+      } else if (character === ')') {
+        argumentIndexes.pop()
+      }
+    }
+
+    const term = match[0]
+    parts.push(
+      argumentIndexes.length > 0 && !isPredicateName(text, end)
+        ? <ColoredTerm
+            key={`${start}-${term}`}
+            term={term}
+            colorIndex={argumentIndexes[argumentIndexes.length - 1]}
+          />
+        : term
+    )
+    cursor = end
+  }
+
+  parts.push(text.slice(cursor))
+  return <>{parts}</>
+}

--- a/src/components/ColoredLogicText.tsx
+++ b/src/components/ColoredLogicText.tsx
@@ -11,7 +11,7 @@ const TERM_PATTERN = /(\?[A-Za-z_][A-Za-z0-9_]*|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\]
 
 const TERM_COLORS = [
   '#8f86bf',
-  '#d95f55',
+  '#fb8072',
   '#1f9e89',
   '#2f7fb8',
   '#d6811c',
@@ -22,22 +22,6 @@ const TERM_COLORS = [
   '#6faa65',
   '#c7a600',
 ] as const
-
-// const TERM_COLORS = [
-// '#8dd3c7',
-// '#ffffb3',
-// '#bebada',
-// '#fb8072',
-// '#80b1d3',
-// '#fdb462',
-// '#b3de69',
-// '#fccde5',
-// '#d9d9d9',
-// '#bc80bd',
-// '#ccebc5',
-// '#ffed6f',
-// ] as const
-
 
 const CODE_COLORS = {
   rule: '#0000ff',

--- a/src/components/ColoredLogicText.tsx
+++ b/src/components/ColoredLogicText.tsx
@@ -1,5 +1,5 @@
 import { useContext, type ReactNode } from 'react'
-import { LogicColorizationContext } from './logicColorization'
+import { LOGIC_COLORIZATION_MODES, LogicColorizationContext } from './logicColorization'
 
 type ColoredLogicTextProps = {
   text: string
@@ -10,14 +10,40 @@ type ColoredLogicTextProps = {
 const TERM_PATTERN = /(\?[A-Za-z_][A-Za-z0-9_]*|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[A-Za-z_][A-Za-z0-9_]*|-?\d+(?:\.\d+)?)/g
 
 const TERM_COLORS = [
-  { text: '#a0006d', background: '#ffc4ea' },
-  { text: '#0756a3', background: '#b9dcff' },
-  { text: '#a13c00', background: '#ffd2ad' },
-  { text: '#b42318', background: '#ffc7c2' },
-  { text: '#5b21b6', background: '#dec9ff' },
-  { text: '#6f3f17', background: '#e7c8aa' },
-  { text: '#334155', background: '#d5dbe3' },
+  '#8f86bf',
+  '#d95f55',
+  '#1f9e89',
+  '#2f7fb8',
+  '#d6811c',
+  '#6fa632',
+  '#d66aa7',
+  '#7f7f7f',
+  '#9b5aa3',
+  '#6faa65',
+  '#c7a600',
 ] as const
+
+// const TERM_COLORS = [
+// '#8dd3c7',
+// '#ffffb3',
+// '#bebada',
+// '#fb8072',
+// '#80b1d3',
+// '#fdb462',
+// '#b3de69',
+// '#fccde5',
+// '#d9d9d9',
+// '#bc80bd',
+// '#ccebc5',
+// '#ffed6f',
+// ] as const
+
+
+const CODE_COLORS = {
+  rule: '#0000ff',
+  parameter: '#008000',
+  constant: '#800000',
+} as const
 
 function colorForIndex(index: number) {
   return TERM_COLORS[index % TERM_COLORS.length]
@@ -27,16 +53,26 @@ function isPredicateName(text: string, end: number) {
   return text.slice(end).trimStart().startsWith('(')
 }
 
+function codeColorForTerm(term: string, isRule: boolean) {
+  if (isRule) {
+    return CODE_COLORS.rule
+  }
+  if (term.startsWith('?')) {
+    return CODE_COLORS.parameter
+  }
+  return CODE_COLORS.constant
+}
+
 function ColoredTerm({ term, colorIndex }: Readonly<{ term: string; colorIndex: number }>) {
   const mode = useContext(LogicColorizationContext)
-  const color = colorForIndex(colorIndex)
+  if (mode === LOGIC_COLORIZATION_MODES.none) {
+    return term
+  }
+
   return (
     <span
       style={{
-        color: color.text,
-        backgroundColor: mode === 'background' ? color.background : undefined,
-        borderRadius: mode === 'background' ? 3 : undefined,
-        boxShadow: mode === 'background' ? `0 0 0 2px ${color.background}` : undefined,
+        color: mode === LOGIC_COLORIZATION_MODES.code ? codeColorForTerm(term, false) : colorForIndex(colorIndex),
       }}
     >
       {term}
@@ -44,11 +80,25 @@ function ColoredTerm({ term, colorIndex }: Readonly<{ term: string; colorIndex: 
   )
 }
 
+function ColoredCodeToken({ term, isRule }: Readonly<{ term: string; isRule: boolean }>) {
+  const mode = useContext(LogicColorizationContext)
+  if (mode !== LOGIC_COLORIZATION_MODES.code) {
+    return term
+  }
+
+  return <span style={{ color: codeColorForTerm(term, isRule) }}>{term}</span>
+}
+
 export default function ColoredLogicText({
   text,
   standaloneTerm = false,
   colorIndex = 0,
 }: Readonly<ColoredLogicTextProps>) {
+  const mode = useContext(LogicColorizationContext)
+  if (mode === LOGIC_COLORIZATION_MODES.none) {
+    return text
+  }
+
   if (standaloneTerm) {
     return <ColoredTerm term={text} colorIndex={colorIndex} />
   }
@@ -74,8 +124,12 @@ export default function ColoredLogicText({
     }
 
     const term = match[0]
+    const isRule = isPredicateName(text, end)
+    const shouldColorTextTerm = argumentIndexes.length > 0 && !isRule
     parts.push(
-      argumentIndexes.length > 0 && !isPredicateName(text, end)
+      mode === LOGIC_COLORIZATION_MODES.code
+        ? <ColoredCodeToken key={`${start}-${term}`} term={term} isRule={isRule} />
+        : shouldColorTextTerm
         ? <ColoredTerm
             key={`${start}-${term}`}
             term={term}
@@ -87,5 +141,5 @@ export default function ColoredLogicText({
   }
 
   parts.push(text.slice(cursor))
-  return <>{parts}</>
+  return <span style={{ whiteSpace: 'pre' }}>{parts}</span>
 }

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Tree from "../Tree/Tree";
-import { Snackbar, Tooltip, Button, Slider, Box, Input, Alert } from "@mui/material";
+import { Snackbar, Tooltip, Button, Slider, Box, Input, Alert, FormControlLabel, Switch } from "@mui/material";
 import { DataManager } from "./DataManager";
 import { RuleNodeData, TableNodeData, TreeNodeData } from "../../data/TreeNodeData";
 import './../../assets/index.css'
@@ -15,6 +15,8 @@ import { StringFormatter } from "../../util/StringFormatter";
 import { findDeepestLeaf } from "../../util/findDeepestLeaf";
 import TextField from '@mui/material/TextField';
 import { ToggleButton, ToggleButtonGroup }  from "@mui/material";
+import ColoredLogicText from "../ColoredLogicText";
+import { LogicColorizationContext, type LogicColorizationMode } from "../logicColorization";
 
 type SceneProps = {
   error: string | null;
@@ -89,6 +91,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
 
   const [editQueryOpen, setEditQueryOpen] = useState(false);
   const [maxLength, setMaxLength] = useState(StringFormatter.maxLengthSlider);
+  const [colorizationMode, setColorizationMode] = useState<LogicColorizationMode>("text");
 
   useEffect(() => {
     setMaxLength(StringFormatter.maxLengthSlider);
@@ -431,6 +434,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
   }
 
   return (
+    <LogicColorizationContext.Provider value={colorizationMode}>
     <div style={{ position: "relative" }}>
       {/* Top right action buttons */}
       <div style={{ position: "absolute", top: 16, right: 16, zIndex: 1, display: "flex", flexDirection: "column", gap: 8, backgroundColor: "white", padding: 16, borderRadius: 8, boxShadow: "0 2px 8px rgba(0, 0, 0, 0.1)" }}>
@@ -500,7 +504,9 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
           <div>
             <b>Current Predicate:</b>
             <div style={{ whiteSpace: "nowrap" }}>
-              {rootNode.getName() || "—"}
+              {rootNode.getName()
+                ? <ColoredLogicText text={StringFormatter.getInstance().formatPredicate(rootNode.getName(), false, rootNode.parameterPredicate)} />
+                : "—"}
             </div>
           </div>
           <div style={{ marginTop: 4 }}>
@@ -569,6 +575,25 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
               sx={{ width: 60 }}
             />
           </Box>
+        </Tooltip>
+
+        <Tooltip
+          title="Switch between colored text and colored text with matching backgrounds."
+          placement="left"
+          enterDelay={500}
+        >
+          <FormControlLabel
+            sx={{ margin: 0, justifyContent: "space-between", fontSize: 14 }}
+            label="Color backgrounds"
+            labelPlacement="start"
+            control={
+              <Switch
+                size="small"
+                checked={colorizationMode === "background"}
+                onChange={(_, checked) => setColorizationMode(checked ? "background" : "text")}
+              />
+            }
+          />
         </Tooltip>
 
         <Box sx={{ display: "flex", gap: 1.5, marginTop: 2 }}>
@@ -703,6 +728,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
         onApply={handleRestriction}
       />
     </div>
+    </LogicColorizationContext.Provider>
   );
 }
 

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -16,7 +16,7 @@ import { findDeepestLeaf } from "../../util/findDeepestLeaf";
 import TextField from '@mui/material/TextField';
 import { ToggleButton, ToggleButtonGroup }  from "@mui/material";
 import ColoredLogicText from "../ColoredLogicText";
-import { LogicColorizationContext, type LogicColorizationMode } from "../logicColorization";
+import { LOGIC_COLORIZATION_MODES, LogicColorizationContext, type LogicColorizationMode } from "../logicColorization";
 
 type SceneProps = {
   error: string | null;
@@ -91,7 +91,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
 
   const [editQueryOpen, setEditQueryOpen] = useState(false);
   const [maxLength, setMaxLength] = useState(StringFormatter.maxLengthSlider);
-  const [colorizationMode, setColorizationMode] = useState<LogicColorizationMode>("text");
+  const [colorizationMode, setColorizationMode] = useState<LogicColorizationMode>(LOGIC_COLORIZATION_MODES.text);
 
   useEffect(() => {
     setMaxLength(StringFormatter.maxLengthSlider);
@@ -578,19 +578,38 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
         </Tooltip>
 
         <Tooltip
-          title="Switch between colored text and colored text with matching backgrounds."
+          title="Toggle logic variable text colors."
           placement="left"
           enterDelay={500}
         >
           <FormControlLabel
             sx={{ margin: 0, justifyContent: "space-between", fontSize: 14 }}
-            label="Color backgrounds"
+            label="Color variables"
             labelPlacement="start"
             control={
               <Switch
                 size="small"
-                checked={colorizationMode === "background"}
-                onChange={(_, checked) => setColorizationMode(checked ? "background" : "text")}
+                checked={colorizationMode === LOGIC_COLORIZATION_MODES.text}
+                onChange={(_, checked) => setColorizationMode(checked ? LOGIC_COLORIZATION_MODES.text : LOGIC_COLORIZATION_MODES.none)}
+              />
+            }
+          />
+        </Tooltip>
+
+        <Tooltip
+          title="Use Nemo-style code colors for rules, parameters, and constants."
+          placement="left"
+          enterDelay={500}
+        >
+          <FormControlLabel
+            sx={{ margin: 0, justifyContent: "space-between", fontSize: 14 }}
+            label="Code mode"
+            labelPlacement="start"
+            control={
+              <Switch
+                size="small"
+                checked={colorizationMode === LOGIC_COLORIZATION_MODES.code}
+                onChange={(_, checked) => setColorizationMode(checked ? LOGIC_COLORIZATION_MODES.code : LOGIC_COLORIZATION_MODES.none)}
               />
             }
           />

--- a/src/components/Scene/TableDialog.tsx
+++ b/src/components/Scene/TableDialog.tsx
@@ -11,6 +11,7 @@ import { FaMagnifyingGlass } from 'react-icons/fa6';
 import StringFormatter from '../../util/StringFormatter';
 import type { TableEntryResponse, TableColumn, ColumnParams } from '../../types/types';
 import PaginationBar from './Pagination';
+import ColoredLogicText from '../ColoredLogicText';
 
 type TableProps = {
     node: TableNodeData | null;
@@ -61,7 +62,14 @@ function TableDialog({
                 ...entries[0].termTuple.map((_, idx) => ({
                     field: `col${idx}`,
                     headerName: node.parameterPredicate[idx] === undefined ? `var${idx}` : `${node.parameterPredicate[idx]}`,
-                    width: 150
+                    width: 150,
+                    renderCell: (params: ColumnParams) => (
+                        <ColoredLogicText
+                            text={params.row[`col${idx}`] ?? ""}
+                            standaloneTerm
+                            colorIndex={idx}
+                        />
+                    ),
                 })),
                 {
                     field: "action",
@@ -99,7 +107,14 @@ function TableDialog({
                 ...entries[0].termTuple.map((_, idx) => ({
                 field: `col${idx}`,
                 headerName: node.parameterPredicate[idx] === undefined ? `var${idx}` : `${node.parameterPredicate[idx]}`,
-                width: 150
+                width: 150,
+                renderCell: (params: ColumnParams) => (
+                    <ColoredLogicText
+                        text={params.row[`col${idx}`] ?? ""}
+                        standaloneTerm
+                        colorIndex={idx}
+                    />
+                ),
             }))
             ];
         }
@@ -108,7 +123,7 @@ function TableDialog({
     return (
         <Dialog open={open} onClose={onClose} fullScreen scroll="paper">
             <DialogTitle>
-                Table: {StringFormatter.formatPredicate(node.getName(), false, node.parameterPredicate)}
+                Table: <ColoredLogicText text={StringFormatter.formatPredicate(node.getName(), false, node.parameterPredicate)} />
                 <Tooltip title="Leave fullscreen mode!" placement="left" enterDelay={500}>
                     <IconButton aria-label="panel" onClick={onTogglePanel} sx={{ position: "absolute", right: 8, top: 8 }}>
                         <FaCompress />

--- a/src/components/Scene/TableDialogPanel.tsx
+++ b/src/components/Scene/TableDialogPanel.tsx
@@ -13,6 +13,7 @@ import StringFormatter from '../../util/StringFormatter';
 import { HIGHLIGHTING_COLORS } from '../../types/constants';
 import type { TableEntryResponse, TableColumn, ColumnParams } from '../../types/types';
 import PaginationBar from './Pagination';
+import ColoredLogicText from '../ColoredLogicText';
 
 type TableDialogPanelProps = {
     nodes: TableNodeData[];
@@ -181,6 +182,13 @@ function SingleTablePanel({
                     field: `col${idx}`,
                     headerName: node.parameterPredicate[idx] === undefined ? `var${idx}` : `${node.parameterPredicate[idx]}`,
                     width: 150,
+                    renderCell: (params: ColumnParams) => (
+                        <ColoredLogicText
+                            text={params.row[`col${idx}`] ?? ""}
+                            standaloneTerm
+                            colorIndex={idx}
+                        />
+                    ),
                 })),
                 {
                     field: "action",
@@ -220,6 +228,13 @@ function SingleTablePanel({
                 field: `col${idx}`,
                 headerName: node.parameterPredicate[idx] === undefined ? `var${idx}` : `${node.parameterPredicate[idx]}`,
                 width: 150,
+                renderCell: (params: ColumnParams) => (
+                    <ColoredLogicText
+                        text={params.row[`col${idx}`] ?? ""}
+                        standaloneTerm
+                        colorIndex={idx}
+                    />
+                ),
             }))
             ];
         }
@@ -292,7 +307,7 @@ function SingleTablePanel({
                         marginBottom: 12
                     }}
                 >
-                    Table: {StringFormatter.formatPredicate(node.getName(), false, node.parameterPredicate)}
+                    Table: <ColoredLogicText text={StringFormatter.formatPredicate(node.getName(), false, node.parameterPredicate)} />
                     {node.isOutdated && <span style={{ color: "#d32f2f", marginLeft: 8 }}>(outdated)</span>}
                 </span>
             </Tooltip>

--- a/src/components/Tree/IndentedTree.tsx
+++ b/src/components/Tree/IndentedTree.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from '@mui/material'
 import { TableNodeData, type TreeNodeData } from '../../data/TreeNodeData'
 import StringFormatter from '../../util/StringFormatter'
+import ColoredLogicText from '../ColoredLogicText'
 
 type FlatRow = {
   node: TreeNodeData
@@ -122,10 +123,12 @@ function IndentedTreeRow({
     <span style={{ color: '#999', marginRight: '6px' }}>#{rowIndex}</span>
     {prefix}
     {(caret ? caret : ' ') + ' '}
-    {(row.node instanceof TableNodeData)
-      ? StringFormatter.formatPredicate(row.node.getName(), false, row.node.parameterPredicate)
-      : StringFormatter.formatRuleName(row.node.getName(), false)
-    }
+    <ColoredLogicText
+      text={(row.node instanceof TableNodeData)
+        ? StringFormatter.formatPredicate(row.node.getName(), false, row.node.parameterPredicate)
+        : StringFormatter.formatRuleName(row.node.getName(), false)
+      }
+    />
   </div>
 );
 

--- a/src/components/Tree/Node/RuleNodeBox.tsx
+++ b/src/components/Tree/Node/RuleNodeBox.tsx
@@ -2,6 +2,7 @@ import Tooltip from '@mui/material/Tooltip'
 import '../../../assets/NodeBox.css'
 import type { RuleNodeData } from '../../../data/TreeNodeData'
 import StringFormatter from '../../../util/StringFormatter'
+import ColoredLogicText from '../../ColoredLogicText'
 
 type NodeBoxProps = {
   node: RuleNodeData
@@ -23,7 +24,7 @@ export function RuleNodeBox({ node, onMouseEnter }: Readonly<NodeBoxProps>) {
         minHeight: 33,
       }}
     >
-      {StringFormatter.formatRuleName(ruleName, true)}
+      <ColoredLogicText text={StringFormatter.formatRuleName(ruleName, true)} />
     </div>
   );
 

--- a/src/components/Tree/Node/TableNodeBox.tsx
+++ b/src/components/Tree/Node/TableNodeBox.tsx
@@ -8,6 +8,7 @@ import StringFormatter from '../../../util/StringFormatter'
 import { FaMagnifyingGlass, FaTable } from 'react-icons/fa6'
 import { HIGHLIGHTING_COLORS } from '../../../types/constants'
 import type { TableEntryResponse } from '../../../types/types'
+import ColoredLogicText from '../../ColoredLogicText'
 
 type NodeBoxProps = {
   node: TableNodeData
@@ -51,10 +52,10 @@ function TableNodeHeader({
       >
         {needsTooltip ? (
           <Tooltip title={unshortenedFormattedName} placement="top" enterDelay={800}>
-            <span style={{ whiteSpace: "nowrap"}}>&nbsp;{formattedName}&nbsp;</span>
+            <span style={{ whiteSpace: "nowrap"}}>&nbsp;<ColoredLogicText text={formattedName} />&nbsp;</span>
           </Tooltip>
         ) : (
-          <span style={{ whiteSpace: "nowrap"}}>&nbsp;{formattedName}&nbsp;</span>
+          <span style={{ whiteSpace: "nowrap"}}>&nbsp;<ColoredLogicText text={formattedName} />&nbsp;</span>
         )}
       </div>
     </Tooltip>
@@ -183,7 +184,13 @@ function TableNodeDetails({ node, mode, onRowClicked, onPopOutClicked }: Readonl
                               >
                                 {col.renderCell(row)}
                               </td>
-                              : <td key={cellKey} style={{ padding: "3px 8px" }}>{row.termTuple[colIdx] ?? ""}</td>
+                              : <td key={cellKey} style={{ padding: "3px 8px" }}>
+                                <ColoredLogicText
+                                  text={row.termTuple[colIdx] ?? ""}
+                                  standaloneTerm
+                                  colorIndex={colIdx}
+                                />
+                              </td>
                           );
                         })}
                       </tr>

--- a/src/components/logicColorization.ts
+++ b/src/components/logicColorization.ts
@@ -1,5 +1,11 @@
 import { createContext } from 'react'
 
-export type LogicColorizationMode = 'text' | 'background'
+export const LOGIC_COLORIZATION_MODES = {
+  none: 'none',
+  text: 'text',
+  code: 'code',
+} as const
 
-export const LogicColorizationContext = createContext<LogicColorizationMode>('text')
+export type LogicColorizationMode = typeof LOGIC_COLORIZATION_MODES[keyof typeof LOGIC_COLORIZATION_MODES]
+
+export const LogicColorizationContext = createContext<LogicColorizationMode>(LOGIC_COLORIZATION_MODES.text)

--- a/src/components/logicColorization.ts
+++ b/src/components/logicColorization.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+export type LogicColorizationMode = 'text' | 'background'
+
+export const LogicColorizationContext = createContext<LogicColorizationMode>('text')


### PR DESCRIPTION

- Color predicate and rule variables by argument position
- Support text-only and text-with-background variants
- Add a compact mode switch to the right settings panel
- Apply matching colors across tree nodes, overview trees, tables, dialogs, and predicate summaries

text only colorization:

<img width="1728" height="844" alt="Screenshot 2026-06-15 at 10 32 12 AM" src="https://github.com/user-attachments/assets/3edfb493-931d-46fb-8bf3-fbba231c608a" />


with background colorization:

<img width="1728" height="855" alt="Screenshot 2026-06-15 at 10 32 20 AM" src="https://github.com/user-attachments/assets/b97d86f2-81e0-49e8-a69c-1d31c375ece6" />
