### PR TITLE
fix: remove hastag from line numbers indented tree

### DIFF
--- a/src/components/Tree/IndentedTree.tsx
+++ b/src/components/Tree/IndentedTree.tsx
@@ -119,7 +119,7 @@ function IndentedTreeRow({
       onNodeClicked(row.node, false);
     }}
   >
-    <span style={{ color: '#999', marginRight: '6px' }}>#{rowIndex}</span>
+    <span style={{ color: '#999', marginRight: '6px' }}>{rowIndex}</span>
     {prefix}
     {(caret ? caret : ' ') + ' '}
     {(row.node instanceof TableNodeData)


### PR DESCRIPTION
before:

<img width="399" height="97" alt="Screenshot 2026-06-20 at 2 17 48 PM" src="https://github.com/user-attachments/assets/ed1e1b18-b4df-4fcb-a0ed-2ca9f7f7091d" />

after:

<img width="399" height="93" alt="Screenshot 2026-06-20 at 2 17 36 PM" src="https://github.com/user-attachments/assets/ce46eb75-d44a-46ec-a7e9-bdf5f2438357" />
