### PR TITLE
feat: add breadcrumb

### DIFF
--- a/src/assets/Overlay.css
+++ b/src/assets/Overlay.css
@@ -37,3 +37,22 @@
 .re-resizable .resizable-handle:hover {
   background: rgba(25, 118, 210, 0.5);
 }
+
+.indented-tree {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  font-size: 15px;
+  height: 100%;
+  line-height: 1.2;
+  min-height: 0;
+  width: 100%;
+}
+
+.indented-tree__rows {
+  box-sizing: border-box;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  width: 100%;
+}

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -6,3 +6,85 @@ html, body, #root {
   margin: 0;
   padding: 0;
 }
+
+.page-breadcrumb-footer {
+  align-items: center;
+  background: #fff;
+  border-top: 1px solid #dfe4ea;
+  bottom: 0;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.06);
+  box-sizing: border-box;
+  display: flex;
+  height: 42px;
+  left: 0;
+  padding: 0 12px;
+  position: fixed;
+  right: 0;
+  z-index: 5;
+}
+
+.tree-breadcrumb {
+  align-items: center;
+  box-sizing: border-box;
+  color: #444;
+  display: flex;
+  font-size: 15px;
+  line-height: 1.2;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  user-select: none;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.tree-breadcrumb__item {
+  display: inline-flex;
+  flex: 0 0 auto;
+  transition: opacity 0.12s ease;
+}
+
+.tree-breadcrumb__item--dimmed {
+  opacity: 0.32;
+}
+
+.tree-breadcrumb__button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  margin: 0;
+  max-width: 28ch;
+  overflow: hidden;
+  padding: 2px 0;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tree-breadcrumb__button:hover,
+.tree-breadcrumb__button:focus-visible {
+  text-decoration: underline;
+}
+
+.tree-breadcrumb__button:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid #217dbb;
+  outline-offset: 2px;
+}
+
+.tree-breadcrumb__item--predicate {
+  color: #43a047;
+}
+
+.tree-breadcrumb__item--rule {
+  color: #217dbb;
+}
+
+.tree-breadcrumb__separator {
+  color: #999;
+  padding: 0 8px;
+}

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -7,12 +7,11 @@ html, body, #root {
   padding: 0;
 }
 
-.page-breadcrumb-footer {
+.page-breadcrumb-header {
   align-items: center;
   background: #fff;
-  border-top: 1px solid #dfe4ea;
-  bottom: 0;
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.06);
+  border-bottom: 1px solid #dfe4ea;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   box-sizing: border-box;
   display: flex;
   height: 42px;
@@ -20,6 +19,7 @@ html, body, #root {
   padding: 0 12px;
   position: fixed;
   right: 0;
+  top: 0;
   z-index: 5;
 }
 
@@ -29,6 +29,7 @@ html, body, #root {
   color: #444;
   display: flex;
   font-size: 15px;
+  height: 100%;
   line-height: 1.2;
   min-width: 0;
   overflow-x: auto;
@@ -65,6 +66,12 @@ html, body, #root {
   white-space: nowrap;
 }
 
+.tree-breadcrumb__button--full {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
+}
+
 .tree-breadcrumb__button:hover,
 .tree-breadcrumb__button:focus-visible {
   text-decoration: underline;
@@ -85,6 +92,9 @@ html, body, #root {
 }
 
 .tree-breadcrumb__separator {
+  align-items: center;
   color: #999;
+  display: inline-flex;
+  font-size: 0.7em;
   padding: 0 8px;
 }

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -17,6 +17,7 @@ import TextField from '@mui/material/TextField';
 import { ToggleButton, ToggleButtonGroup }  from "@mui/material";
 import ColoredLogicText from "../ColoredLogicText";
 import { LOGIC_COLORIZATION_MODES, LogicColorizationContext, type LogicColorizationMode } from "../logicColorization";
+import TreeBreadcrumb from "../Tree/TreeBreadcrumb";
 
 type SceneProps = {
   error: string | null;
@@ -28,6 +29,8 @@ type SceneProps = {
 // ...imports...
 
 function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps) {
+  const breadcrumbFooterHeight = 42;
+
   // State for window dimensions
   const [dimensions, setDimensions] = useState({
     width: window.innerWidth,
@@ -45,6 +48,12 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
 
   // State for currently hovered node in the tree
   const [hoveredNode, setHoveredNode] = useState<TreeNodeData | null>(null);
+
+  // State for the node whose breadcrumb should remain visible after hover ends
+  const [breadcrumbNode, setBreadcrumbNode] = useState<TreeNodeData | null>(null);
+
+  // State for highlighting tree nodes when hovering breadcrumb items
+  const [breadcrumbHoveredNode, setBreadcrumbHoveredNode] = useState<TreeNodeData | null>(null);
 
   // State / Node for maximized table dialog
   const [maximizedTable, setMaximizedTable] = useState<TableNodeData | null>(null);
@@ -304,8 +313,19 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
     setPanToNodeId({ node: leaf, center: true });
   };
 
+  const handleBreadcrumbNodeClick = (node: TreeNodeData) => {
+    setBreadcrumbNode(node);
+    setPanToNodeId({ node, center: true });
+
+    if (mode === "explore") {
+      setFocusClicked(node);
+      handleFocusNode(node, false);
+    }
+  };
+
   // Handle clicking a node in the tree (isExpanded)
   const handleNodeClick = (node: TreeNodeData) => {
+    setBreadcrumbNode(node);
     dataManager.changeNodeLayout(node, node.isExpanded);
     setTreeVersion(v => v + 1);
   };
@@ -433,6 +453,9 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
     dataManager.setFlagFocusOnNode(rootNode, node, "isGreyed");
     setTreeVersion(v => v + 1);
   }
+
+  const currentBreadcrumbNode = hoveredNode ?? breadcrumbNode;
+  const highlightedNode = breadcrumbHoveredNode ?? currentBreadcrumbNode;
 
   return (
     <LogicColorizationContext.Provider value={colorizationMode}>
@@ -692,11 +715,11 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
         giveRemoveAbovePreview={handleRemoveAbovePreview}
         giveRemoveBelowPreview={handleRemoveEdgePreview}
         panToNodeId={panToNodeId}
-        hoveredNode={hoveredNode}
+        hoveredNode={highlightedNode}
         setHoveredNode={setHoveredNode}
         treeVersion={treeVersion}
         width={dimensions.width}
-        height={dimensions.height}
+        height={Math.max(0, dimensions.height - breadcrumbFooterHeight)}
         codingButtonClicked={codingButtonClicked}
         onRemoveAboveButtonClick={handleRemoveAboveButtonClick}
         onRemoveBelowButtonClick={handleRemoveBelowButtonClick}
@@ -721,9 +744,10 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
         open={showSidePanel}
         onClose={() => setShowSidePanel(!showSidePanel)}
         rootNode={rootNode}
-        hoveredNode={hoveredNode}
+        hoveredNode={highlightedNode}
         setHoveredNode={setHoveredNode}
         onNodeClick={(node, bool) => {
+          setBreadcrumbNode(node);
           setPanToNodeId({ node: node, center: true });
 
           if (mode === "explore") {
@@ -738,6 +762,15 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
           }
         }}
       />
+
+      <div className="page-breadcrumb-footer">
+        <TreeBreadcrumb
+          rootNode={rootNode}
+          currentNode={currentBreadcrumbNode}
+          onNodeClick={handleBreadcrumbNodeClick}
+          onNodeHover={setBreadcrumbHoveredNode}
+        />
+      </div>
 
       <EditQueryDialog
         open={editQueryOpen}

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -29,7 +29,7 @@ type SceneProps = {
 // ...imports...
 
 function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps) {
-  const breadcrumbFooterHeight = 42;
+  const breadcrumbHeaderHeight = 42;
 
   // State for window dimensions
   const [dimensions, setDimensions] = useState({
@@ -66,6 +66,9 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
 
   // State for search value
   const [searchValue, setSearchValue] = useState("");
+
+  // Whether breadcrumb labels should be displayed without truncation
+  const [showFullBreadcrumbLabels, setShowFullBreadcrumbLabels] = useState(false);
 
   // State for focused node in the tree
   const [focusClicked, setFocusClicked] = useState<TreeNodeData | null>(null);
@@ -461,7 +464,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
     <LogicColorizationContext.Provider value={colorizationMode}>
     <div style={{ position: "relative" }}>
       {/* Top right action buttons */}
-      <div style={{ position: "absolute", top: 16, right: 16, zIndex: 1, display: "flex", flexDirection: "column", gap: 8, backgroundColor: "white", padding: 16, borderRadius: 8, boxShadow: "0 2px 8px rgba(0, 0, 0, 0.1)" }}>
+      <div style={{ position: "absolute", top: breadcrumbHeaderHeight + 16, right: 16, zIndex: 1, display: "flex", flexDirection: "column", gap: 8, backgroundColor: "white", padding: 16, borderRadius: 8, boxShadow: "0 2px 8px rgba(0, 0, 0, 0.1)" }}>
         <div style={{textAlign:"center"}}>
         <ToggleButtonGroup
           size="small"
@@ -602,6 +605,25 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
         </Tooltip>
 
         <Tooltip
+          title="Show complete labels in the breadcrumb; long paths can be scrolled horizontally."
+          placement="left"
+          enterDelay={500}
+        >
+          <FormControlLabel
+            sx={{ margin: 0, justifyContent: "space-between", fontSize: 14 }}
+            label="Full breadcrumb labels"
+            labelPlacement="start"
+            control={
+              <Switch
+                size="small"
+                checked={showFullBreadcrumbLabels}
+                onChange={(_, checked) => setShowFullBreadcrumbLabels(checked)}
+              />
+            }
+          />
+        </Tooltip>
+
+        <Tooltip
           title="Toggle logic variable text colors."
           placement="left"
           enterDelay={500}
@@ -708,40 +730,53 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
         />
       )}
 
+      <div className="page-breadcrumb-header">
+        <TreeBreadcrumb
+          rootNode={rootNode}
+          currentNode={currentBreadcrumbNode}
+          showFullLabels={showFullBreadcrumbLabels}
+          onNodeClick={handleBreadcrumbNodeClick}
+          onNodeHover={setBreadcrumbHoveredNode}
+        />
+      </div>
+
       {/* Main tree visualization */}
-      <Tree
-        data={rootNode}
-        mode={mode}
-        giveRemoveAbovePreview={handleRemoveAbovePreview}
-        giveRemoveBelowPreview={handleRemoveEdgePreview}
-        panToNodeId={panToNodeId}
-        hoveredNode={highlightedNode}
-        setHoveredNode={setHoveredNode}
-        treeVersion={treeVersion}
-        width={dimensions.width}
-        height={Math.max(0, dimensions.height - breadcrumbFooterHeight)}
-        codingButtonClicked={codingButtonClicked}
-        onRemoveAboveButtonClick={handleRemoveAboveButtonClick}
-        onRemoveBelowButtonClick={handleRemoveBelowButtonClick}
-        onAddAboveButtonClick={handleAddRuleAboveButtonClick}
-        onAddBelowButtonClick={handleAddRuleBelowButtonClick}
-        onCollapseButtonClick={handleCollapseButtonClick}
-        onMouseLeftButton={() => handleResetEffect("isGreyed")}
-        giveFocusPreview={handleFocusPreview}
-        handleRemoveEdgePreview={handleRemoveEdgePreview}
-        onNodeClicked={handleNodeClick}
-        onFocusButtonClick={handleRuleFocusButtonClick}
-        onFocusNode={handleFocusNode}
-        onRowClicked={handleFocusOnRow}
-        onPopOutClicked={handleShowTable}
-        setPanToNodeId={setPanToNodeId}
-        setFocusClicked={setFocusClicked}
-        focusClicked={focusClicked}
-      />
+      <div style={{ paddingTop: breadcrumbHeaderHeight }}>
+        <Tree
+          data={rootNode}
+          mode={mode}
+          giveRemoveAbovePreview={handleRemoveAbovePreview}
+          giveRemoveBelowPreview={handleRemoveEdgePreview}
+          panToNodeId={panToNodeId}
+          hoveredNode={highlightedNode}
+          setHoveredNode={setHoveredNode}
+          treeVersion={treeVersion}
+          width={dimensions.width}
+          height={Math.max(0, dimensions.height - breadcrumbHeaderHeight)}
+          codingButtonClicked={codingButtonClicked}
+          onRemoveAboveButtonClick={handleRemoveAboveButtonClick}
+          onRemoveBelowButtonClick={handleRemoveBelowButtonClick}
+          onAddAboveButtonClick={handleAddRuleAboveButtonClick}
+          onAddBelowButtonClick={handleAddRuleBelowButtonClick}
+          onCollapseButtonClick={handleCollapseButtonClick}
+          onMouseLeftButton={() => handleResetEffect("isGreyed")}
+          giveFocusPreview={handleFocusPreview}
+          handleRemoveEdgePreview={handleRemoveEdgePreview}
+          onNodeClicked={handleNodeClick}
+          onFocusButtonClick={handleRuleFocusButtonClick}
+          onFocusNode={handleFocusNode}
+          onRowClicked={handleFocusOnRow}
+          onPopOutClicked={handleShowTable}
+          setPanToNodeId={setPanToNodeId}
+          setFocusClicked={setFocusClicked}
+          focusClicked={focusClicked}
+        />
+      </div>
 
       {/* Side panel with indented tree */}
       <SidePanel
         open={showSidePanel}
+        topOffset={breadcrumbHeaderHeight}
         onClose={() => setShowSidePanel(!showSidePanel)}
         rootNode={rootNode}
         hoveredNode={highlightedNode}
@@ -762,15 +797,6 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
           }
         }}
       />
-
-      <div className="page-breadcrumb-footer">
-        <TreeBreadcrumb
-          rootNode={rootNode}
-          currentNode={currentBreadcrumbNode}
-          onNodeClick={handleBreadcrumbNodeClick}
-          onNodeHover={setBreadcrumbHoveredNode}
-        />
-      </div>
 
       <EditQueryDialog
         open={editQueryOpen}

--- a/src/components/Scene/SidePanel.tsx
+++ b/src/components/Scene/SidePanel.tsx
@@ -89,7 +89,7 @@ export default function SidePanel({
               height: "100%",
               padding: 12,
               boxSizing: "border-box",
-              overflowY: "auto",
+              overflow: "hidden",
               transition: "width 0.2s",
             }}
           >

--- a/src/components/Scene/SidePanel.tsx
+++ b/src/components/Scene/SidePanel.tsx
@@ -8,6 +8,7 @@ import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 
 type SidePanelProps = {
   open: boolean;
+  topOffset?: number;
   onClose: (open: boolean) => void;
   rootNode: TreeNodeData;
   hoveredNode: TreeNodeData | null;
@@ -17,6 +18,7 @@ type SidePanelProps = {
 
 export default function SidePanel({
   open,
+  topOffset = 0,
   onClose,
   rootNode,
   hoveredNode,
@@ -32,7 +34,7 @@ export default function SidePanel({
         <Tooltip title="Open the overview tree!" placement="left" enterDelay={500}>
           <button
             className="overlay-toggle-btn"
-            style={{ left: 0 }}
+            style={{ left: 0, top: `calc(50% + ${topOffset / 2}px)` }}
             onClick={() => onClose(true)}
           >
             <IoIosArrowForward />
@@ -46,7 +48,7 @@ export default function SidePanel({
             onClick={() => onClose(false)}
             style={{
               position: 'fixed',
-              top: '50%',
+              top: `calc(50% + ${topOffset / 2}px)`,
               left: drawerWidth - HANDLE_WIDTH,
               transform: 'translateY(-50%)',
               zIndex: 4,
@@ -59,48 +61,55 @@ export default function SidePanel({
       {/* somehow css doesnt work, so inline */}
 
       {open && (
-        <Resizable
-          size={{ width: drawerWidth, height: "100vh" }}
-          minWidth={150}
-          maxWidth={700}
-          enable={{ right: open }}
-          handleStyles={{
-            right: {
-              cursor: "ew-resize",
-            }
-          }}
-          onResize={(_e, _direction, ref) => {
-            setDrawerWidth(ref.offsetWidth);
-          }}
+        <div
           style={{
             position: "fixed",
-            top: 0,
+            top: topOffset,
+            bottom: 0,
             left: 0,
             zIndex: 4,
-            height: "100vh",
-            background: "#fff",
-            boxShadow: open ? "2px 0 8px rgba(0,0,0,0.07)" : undefined,
-            overflow: "hidden"
+            width: drawerWidth,
           }}
         >
-          <div
+          <Resizable
+            size={{ width: drawerWidth, height: "100%" }}
+            minWidth={150}
+            maxWidth={700}
+            enable={{ right: open }}
+            handleStyles={{
+              right: {
+                cursor: "ew-resize",
+              }
+            }}
+            onResize={(_e, _direction, ref) => {
+              setDrawerWidth(ref.offsetWidth);
+            }}
             style={{
-              width: "100%",
+              background: "#fff",
+              boxShadow: "2px 0 8px rgba(0,0,0,0.07)",
               height: "100%",
-              padding: 12,
-              boxSizing: "border-box",
-              overflow: "hidden",
-              transition: "width 0.2s",
+              overflow: "hidden"
             }}
           >
-            <IndentedTree
-              node={rootNode}
-              onNodeClick={onNodeClick}
-              hoveredNode={hoveredNode}
-              setHoveredNode={setHoveredNode}
-            />
-          </div>
-        </Resizable>
+            <div
+              style={{
+                width: "100%",
+                height: "100%",
+                padding: 12,
+                boxSizing: "border-box",
+                overflow: "hidden",
+                transition: "width 0.2s",
+              }}
+            >
+              <IndentedTree
+                node={rootNode}
+                onNodeClick={onNodeClick}
+                hoveredNode={hoveredNode}
+                setHoveredNode={setHoveredNode}
+              />
+            </div>
+          </Resizable>
+        </div>
       )}
     </>
   );

--- a/src/components/Tree/IndentedTree.tsx
+++ b/src/components/Tree/IndentedTree.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from '@mui/material'
 import { TableNodeData, type TreeNodeData } from '../../data/TreeNodeData'
-import StringFormatter from '../../util/StringFormatter'
 import ColoredLogicText from '../ColoredLogicText'
+import { formatNodeLabel } from './treeNodeLabel'
 
 type FlatRow = {
   node: TreeNodeData
@@ -47,19 +47,21 @@ export default function IndentedTree({ node, onNodeClick, hoveredNode, setHovere
   const rowNumberWidth = `${String(rows.length).length + 1}ch`
 
   return (
-    <div style={{ fontSize: 15, lineHeight: 1.2, width: "100%", boxSizing: "border-box" }}>
-      {rows.map((row, idx) => (
-        <IndentedTreeRow
-          key={idx}
-          rowIndex={idx + 1}
-          rowNumberWidth={rowNumberWidth}
-          row={row}
-          onNodeClicked={onNodeClick}
-          hoveredNode={hoveredNode}
-          setHoveredNode={setHoveredNode}
-        />
-      ))}
-      <div style={{ height: 18, userSelect: "none" }} />
+    <div className="indented-tree">
+      <div className="indented-tree__rows">
+        {rows.map((row, idx) => (
+          <IndentedTreeRow
+            key={idx}
+            rowIndex={idx + 1}
+            rowNumberWidth={rowNumberWidth}
+            row={row}
+            onNodeClicked={onNodeClick}
+            hoveredNode={hoveredNode}
+            setHoveredNode={setHoveredNode}
+          />
+        ))}
+        <div style={{ height: 18, userSelect: "none" }} />
+      </div>
     </div>
   )
 }
@@ -139,19 +141,14 @@ function IndentedTreeRow({
     {prefix}
     {(caret ? caret : ' ') + ' '}
     <ColoredLogicText
-      text={(row.node instanceof TableNodeData)
-        ? StringFormatter.formatPredicate(row.node.getName(), false, row.node.parameterPredicate)
-        : StringFormatter.formatRuleName(row.node.getName(), false)
-      }
+      text={formatNodeLabel(row.node)}
     />
   </div>
 );
 
   return (
     <Tooltip title={
-      (row.node instanceof TableNodeData)
-        ? StringFormatter.formatPredicate(row.node.getName(), false, row.node.parameterPredicate)
-        : StringFormatter.formatRuleName(row.node.getName(), false)
+      formatNodeLabel(row.node)
     } placement="right" enterDelay={500}>
       {content}
     </Tooltip>

--- a/src/components/Tree/Node/RuleNode.tsx
+++ b/src/components/Tree/Node/RuleNode.tsx
@@ -6,7 +6,6 @@ import { Tooltip } from '@mui/material'
 import { TbFocus2 } from 'react-icons/tb'
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io'
 import { greyedButtonStyle } from '../../../types/constants'
-import { type Timeouts } from '../../../types/types'
 
 type NodeProps = {
   node: RuleNodeData;
@@ -16,6 +15,7 @@ type NodeProps = {
   isSingleRuleTree: boolean;
   onFocusButtonClick: (node: RuleNodeData) => void;
   onFocusNode: (node: RuleNodeData, bool?: boolean) => void;
+  onNodeClicked: (node: TreeNodeData) => void;
   onCollapseButtonClick: (node: TreeNodeData, bool: boolean) => void;
   isHovered?: boolean;
   onMouseLeftButton: () => void;
@@ -33,23 +33,20 @@ export default function RuleNode({
   onMouseLeftButton,
   giveFocusPreview,
   onCollapseButtonClick,
+  onNodeClicked,
   onFocusButtonClick,
   onFocusNode,
   isHovered,
   setHoveredNode
 }: Readonly<NodeProps>) {
   const [hovered, setHovered] = useState(false);
-  const [hoverMap] = useState<Timeouts>({});
 
   return (
     <div
       className={`custom-node${isHovered ? ' hovered' : ''}`}
       onMouseLeave={() => {
-            const id = node.id.join('');
-            hoverMap[id] = setTimeout(() => {
-                setHovered(false); 
-                setHoveredNode(null)
-            }, 1500) 
+            setHovered(false); 
+            setHoveredNode(null)
         }}
         
       style={{
@@ -59,11 +56,10 @@ export default function RuleNode({
       <RuleNodeBox
         node={node}
         onMouseEnter={() => {
-            const id = node.id.join('');
-            clearTimeout(hoverMap[id]);
             setHovered(true); 
             setHoveredNode(node);
         }}
+        onClick={() => onNodeClicked(node)}
       />
       {hovered && mode === "query" && !isSingleRuleTree && (
         <Tooltip title="Focus on this rule!" placement="right" enterDelay={500}>

--- a/src/components/Tree/Node/RuleNodeBox.tsx
+++ b/src/components/Tree/Node/RuleNodeBox.tsx
@@ -7,9 +7,10 @@ import ColoredLogicText from '../../ColoredLogicText'
 type NodeBoxProps = {
   node: RuleNodeData
   onMouseEnter?: () => void
+  onClick?: () => void
 }
 
-export function RuleNodeBox({ node, onMouseEnter }: Readonly<NodeBoxProps>) {
+export function RuleNodeBox({ node, onMouseEnter, onClick }: Readonly<NodeBoxProps>) {
   const ruleName = node.getName();
   const needsTooltip = StringFormatter.needsRuleTruncation(ruleName);
 
@@ -17,6 +18,7 @@ export function RuleNodeBox({ node, onMouseEnter }: Readonly<NodeBoxProps>) {
     <div
       className={`rule-node-box${node.isGreyed ? ' node-grey' : ''}`}
       onMouseEnter={onMouseEnter}
+      onClick={onClick}
       style={{
         width: node.width,
         height: node.height,

--- a/src/components/Tree/Node/TableNode.tsx
+++ b/src/components/Tree/Node/TableNode.tsx
@@ -8,7 +8,7 @@ import { TbFocus2 } from 'react-icons/tb'
 import { greyedButtonStyle, NORMAL_HEIGHT } from '../../../types/constants'
 import { FaCodeFork, FaCodePullRequest, FaScissors } from 'react-icons/fa6'
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io'
-import type { Rule, TableEntryResponse, Timeouts } from '../../../types/types'
+import type { Rule, TableEntryResponse } from '../../../types/types'
 import PositionDialog from './PositionDialog'
 
 
@@ -56,7 +56,6 @@ export default function TableNode({
 }: Readonly<NodeProps>) {
     const [hovered, setHovered] = useState(false)
     const [activeDialog, setActiveDialog] = useState<"above" | "below" | "pos" | null>(null)    
-    const [hoverMap] = useState<Timeouts>({});
 
     const handleRuleAboveSelect = (rule: Rule, index: number) => {
         setActiveDialog(null)
@@ -71,16 +70,11 @@ export default function TableNode({
         <div
             className={`custom-node${hovered ? ' hovered' : ''}`}
             onMouseLeave={() => {
-                const id = node.id.join('');
-                hoverMap[id] = setTimeout(() => {
-                    setHovered(false);
-                    setHoveredNode(null);
-                }, 1500) 
+                setHovered(false);
+                setHoveredNode(null);
             }}
 
             onMouseEnter={() => {
-                const id = node.id.join('');
-                clearTimeout(hoverMap[id]);
                 setHovered(true); 
                 setHoveredNode(node);
             }}

--- a/src/components/Tree/TreeBreadcrumb.tsx
+++ b/src/components/Tree/TreeBreadcrumb.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Tooltip } from '@mui/material'
+import { FaChevronRight } from 'react-icons/fa'
 import { TableNodeData, type TreeNodeData } from '../../data/TreeNodeData'
 import ColoredLogicText from '../ColoredLogicText'
 import { formatNodeLabel } from './treeNodeLabel'
@@ -42,6 +43,7 @@ function shortenBreadcrumbLabel(label: string) {
 type TreeBreadcrumbProps = {
   rootNode: TreeNodeData
   currentNode: TreeNodeData | null
+  showFullLabels: boolean
   onNodeClick: (node: TreeNodeData) => void
   onNodeHover: (node: TreeNodeData | null) => void
 }
@@ -49,6 +51,7 @@ type TreeBreadcrumbProps = {
 export default function TreeBreadcrumb({
   rootNode,
   currentNode,
+  showFullLabels,
   onNodeClick,
   onNodeHover,
 }: Readonly<TreeBreadcrumbProps>) {
@@ -59,7 +62,7 @@ export default function TreeBreadcrumb({
     <div className="tree-breadcrumb" aria-label="Path from root to current node">
       {breadcrumbPath.map((pathNode, idx) => {
         const fullLabel = formatNodeLabel(pathNode)
-        const shortLabel = shortenBreadcrumbLabel(fullLabel)
+        const displayedLabel = showFullLabels ? fullLabel : shortenBreadcrumbLabel(fullLabel)
 
         return (
           <span
@@ -72,11 +75,15 @@ export default function TreeBreadcrumb({
               hoveredIndex !== null && idx > hoveredIndex ? 'tree-breadcrumb__item--dimmed' : '',
             ].filter(Boolean).join(' ')}
           >
-            {idx > 0 && <span className="tree-breadcrumb__separator">/</span>}
+            {idx > 0 && (
+              <span className="tree-breadcrumb__separator" aria-hidden="true">
+                <FaChevronRight />
+              </span>
+            )}
             <Tooltip title={fullLabel} placement="top" enterDelay={400}>
               <button
                 type="button"
-                className="tree-breadcrumb__button"
+                className={`tree-breadcrumb__button${showFullLabels ? ' tree-breadcrumb__button--full' : ''}`}
                 onClick={() => onNodeClick(pathNode)}
                 onMouseEnter={() => {
                   setHoveredIndex(idx)
@@ -87,7 +94,7 @@ export default function TreeBreadcrumb({
                   onNodeHover(null)
                 }}
               >
-                <ColoredLogicText text={shortLabel} />
+                <ColoredLogicText text={displayedLabel} />
               </button>
             </Tooltip>
           </span>

--- a/src/components/Tree/TreeBreadcrumb.tsx
+++ b/src/components/Tree/TreeBreadcrumb.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { Tooltip } from '@mui/material'
+import { TableNodeData, type TreeNodeData } from '../../data/TreeNodeData'
+import ColoredLogicText from '../ColoredLogicText'
+import { formatNodeLabel } from './treeNodeLabel'
+
+const BREADCRUMB_LABEL_MAX_LENGTH = 28
+
+function findPathToNode(root: TreeNodeData, target: TreeNodeData | null): TreeNodeData[] {
+  if (!target) {
+    return [root]
+  }
+
+  const path: TreeNodeData[] = []
+
+  function visit(node: TreeNodeData): boolean {
+    path.push(node)
+
+    if (node === target) {
+      return true
+    }
+
+    for (const child of node.getChildren()) {
+      if (visit(child)) {
+        return true
+      }
+    }
+
+    path.pop()
+    return false
+  }
+
+  return visit(root) ? path : [root]
+}
+
+function shortenBreadcrumbLabel(label: string) {
+  return label.length > BREADCRUMB_LABEL_MAX_LENGTH
+    ? `${label.slice(0, BREADCRUMB_LABEL_MAX_LENGTH - 1)}…`
+    : label
+}
+
+type TreeBreadcrumbProps = {
+  rootNode: TreeNodeData
+  currentNode: TreeNodeData | null
+  onNodeClick: (node: TreeNodeData) => void
+  onNodeHover: (node: TreeNodeData | null) => void
+}
+
+export default function TreeBreadcrumb({
+  rootNode,
+  currentNode,
+  onNodeClick,
+  onNodeHover,
+}: Readonly<TreeBreadcrumbProps>) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+  const breadcrumbPath = findPathToNode(rootNode, currentNode)
+
+  return (
+    <div className="tree-breadcrumb" aria-label="Path from root to current node">
+      {breadcrumbPath.map((pathNode, idx) => {
+        const fullLabel = formatNodeLabel(pathNode)
+        const shortLabel = shortenBreadcrumbLabel(fullLabel)
+
+        return (
+          <span
+            key={`${idx}-${pathNode.id.join('-')}`}
+            className={[
+              'tree-breadcrumb__item',
+              pathNode instanceof TableNodeData
+                ? 'tree-breadcrumb__item--predicate'
+                : 'tree-breadcrumb__item--rule',
+              hoveredIndex !== null && idx > hoveredIndex ? 'tree-breadcrumb__item--dimmed' : '',
+            ].filter(Boolean).join(' ')}
+          >
+            {idx > 0 && <span className="tree-breadcrumb__separator">/</span>}
+            <Tooltip title={fullLabel} placement="top" enterDelay={400}>
+              <button
+                type="button"
+                className="tree-breadcrumb__button"
+                onClick={() => onNodeClick(pathNode)}
+                onMouseEnter={() => {
+                  setHoveredIndex(idx)
+                  onNodeHover(pathNode)
+                }}
+                onMouseLeave={() => {
+                  setHoveredIndex(null)
+                  onNodeHover(null)
+                }}
+              >
+                <ColoredLogicText text={shortLabel} />
+              </button>
+            </Tooltip>
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/Tree/TreeNodeRenderer.tsx
+++ b/src/components/Tree/TreeNodeRenderer.tsx
@@ -106,6 +106,7 @@ export default function TreeNodeRenderer({
             codingButtonClicked={codingButtonClicked}
             setFocusClicked={setFocusClicked}
             onCollapseButtonClick={onCollapseButtonClick}
+            onNodeClicked={onNodeClicked}
             onFocusButtonClick={onFocusButtonClick}
             onFocusNode={onFocusNode}
             isHovered={hoveredNode === node.data}

--- a/src/components/Tree/treeNodeLabel.ts
+++ b/src/components/Tree/treeNodeLabel.ts
@@ -1,0 +1,10 @@
+import { TableNodeData, type TreeNodeData } from '../../data/TreeNodeData'
+import StringFormatter from '../../util/StringFormatter'
+
+export function formatNodeLabel(node: TreeNodeData) {
+  if (node instanceof TableNodeData) {
+    return StringFormatter.formatPredicate(node.getName(), false, node.parameterPredicate)
+  }
+
+  return StringFormatter.formatRuleName(node.getName(), false)
+}


### PR DESCRIPTION
add breadcrumb in bottom of the page

it is linked to indented tree and tree nodes

screenshot:

<img width="1230" height="956" alt="Screenshot 2026-06-22 at 10 29 23 AM" src="https://github.com/user-attachments/assets/12f54f81-a155-4ae9-9eb5-f9f04796acf5" />
