### PR TITLE
feat: add export tree

### DIFF
--- a/src/assets/NodeBox.css
+++ b/src/assets/NodeBox.css
@@ -32,6 +32,13 @@
   border: 2px solid #4152b1;
 }
 
+.custom-node.selected-for-export > .table-node-box,
+.custom-node.selected-for-export > .rule-node-box {
+  outline: 3px dashed #1976d2;
+  outline-offset: 5px;
+  box-shadow: 0 0 0 8px rgba(25, 118, 210, 0.10);
+}
+
 /* Expandiert */
 .table-node-box--expanded {
   min-height: 120px;

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -7,7 +7,7 @@ import './../../assets/index.css'
 import SidePanel from "./SidePanel";
 import TableDialog from "./TableDialog";
 import type { Rule, TableEntriesForTreeNodesQuery, TableEntriesForTreeNodesResponse, TableEntryResponse, TreeForTableQuery, TreeForTableResponse } from "../../types/types";
-import { FaRedo, FaUndo, FaPenSquare, FaLock, FaArrowUp, FaArrowDown } from "react-icons/fa";
+import { FaRedo, FaUndo, FaPenSquare, FaLock, FaArrowUp, FaArrowDown, FaDownload } from "react-icons/fa";
 import TableDialogPanel from "./TableDialogPanel";
 import { HIGHLIGHTING_COLORS } from "../../types/constants";
 import EditQueryDialog from "./EditQueryDialog";
@@ -93,6 +93,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
   const [maxLength, setMaxLength] = useState(StringFormatter.maxLengthSlider);
   const [showNodeExecutionTimes, setShowNodeExecutionTimes] = useState(false);
   const [colorizationMode, setColorizationMode] = useState<LogicColorizationMode>(LOGIC_COLORIZATION_MODES.text);
+  const [selectedNodes, setSelectedNodes] = useState<TreeNodeData[]>([]);
 
   useEffect(() => {
     setMaxLength(StringFormatter.maxLengthSlider);
@@ -182,6 +183,7 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
       setRootNode(node);
       setQueries(qs);
       node.update()
+      setSelectedNodes([]);
     }
 
     if (message.responseType === "tableEntriesForTreeNodes") {
@@ -303,6 +305,55 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
   const handleJumpToLeaf = () => {
     const leaf = findDeepestLeaf(rootNode);
     setPanToNodeId({ node: leaf, center: true });
+  };
+
+  const handleExport = () => {
+    const selectedAddresses = new Set(selectedNodes.map(node => node.id.join("/")));
+    const allTableNodes: TableNodeData[] = [];
+    const pending: TreeNodeData[] = [rootNode];
+    while (pending.length > 0) {
+      const node = pending.pop();
+      if (!node) continue;
+      if (node instanceof TableNodeData) allTableNodes.push(node);
+      pending.push(...node.getChildren());
+    }
+
+    const nodesToExport = selectedAddresses.size === 0
+      ? allTableNodes
+      : allTableNodes.filter(node => selectedAddresses.has(node.id.join("/")));
+    const exportData: TableEntriesForTreeNodesResponse = nodesToExport.map(node => ({
+      predicate: node.getName(),
+      addressInTree: [...node.id],
+      tableEntries: {
+        entries: node.getTableEntries().map(entry => ({
+          entryId: entry.entryId,
+          termTuple: [...entry.termTuple],
+        })),
+        pagination: {
+          start: node.getPagination().start,
+          moreEntriesExist: node.moreEntriesExist,
+        },
+      },
+      metaInformation: { executionTime: node.executionTime },
+      possibleRulesAbove: node.getRulesAbove(),
+      possibleRulesBelow: node.getRulesBelow(),
+    }));
+
+    if (exportData.length === 0) {
+      setSnackbarMsg({ msg: "The selection contains no table data to export.", sev: "error" });
+      setSnackbarOpen(true);
+      return;
+    }
+
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `nemo-tree-${selectedAddresses.size > 0 ? "selection" : "view"}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+    setSnackbarMsg({ msg: `Exported ${exportData.length} table node${exportData.length === 1 ? "" : "s"}.`, sev: "success" });
+    setSnackbarOpen(true);
   };
 
   // Handle clicking a node in the tree (isExpanded)
@@ -662,6 +713,27 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
             </Button>
           </Tooltip>
         </Box>
+        <Button
+            variant="outlined"
+            size="small"
+            fullWidth
+            startIcon={<FaDownload />}
+            onClick={handleExport}
+            sx={{
+              marginTop: 1,
+              color: "#555b63",
+              borderColor: "#686f78",
+              backgroundColor: "#fafafa",
+              fontWeight: 600,
+              '&:hover': {
+                color: "#383d43",
+                borderColor: "#464c54",
+                backgroundColor: "#eceef0",
+              },
+            }}
+          >
+            Export{selectedNodes.length > 0 ? ` selection (${selectedNodes.length})` : " tree"}
+        </Button>
       </div>
 
       {/* Snackbar for notifications */}
@@ -737,6 +809,8 @@ function Scene({ error, message, sendMessage, codingButtonClicked }: SceneProps)
         setPanToNodeId={setPanToNodeId}
         setFocusClicked={setFocusClicked}
         focusClicked={focusClicked}
+        selectedNodes={selectedNodes}
+        onSelectionChange={setSelectedNodes}
       />
 
       {/* Side panel with indented tree */}

--- a/src/components/Tree/Node/RuleNode.tsx
+++ b/src/components/Tree/Node/RuleNode.tsx
@@ -21,6 +21,7 @@ type NodeProps = {
   giveFocusPreview: (node: TreeNodeData) => void;
   codingButtonClicked: (node: RuleNodeData) => void;
   setHoveredNode: (node: TreeNodeData | null) => void;
+  isSelected: boolean;
 }
 
 export default function RuleNode({
@@ -36,14 +37,15 @@ export default function RuleNode({
   onFocusButtonClick,
   onFocusNode,
   isHovered,
-  setHoveredNode
+  setHoveredNode,
+  isSelected
 }: Readonly<NodeProps>) {
   const [hovered, setHovered] = useState(false);
   const [hoverMap] = useState<Timeouts>({});
 
   return (
     <div
-      className={`custom-node${isHovered ? ' hovered' : ''}`}
+      className={`custom-node${isHovered ? ' hovered' : ''}${isSelected ? ' selected-for-export' : ''}`}
       onMouseLeave={() => {
             const id = node.id.join('');
             hoverMap[id] = setTimeout(() => {

--- a/src/components/Tree/Node/TableNode.tsx
+++ b/src/components/Tree/Node/TableNode.tsx
@@ -34,6 +34,7 @@ type NodeProps = {
     onPopOutClicked: (node: TableNodeData) => void;
     codingButtonClicked: (node: TableNodeData) => void;
     setHoveredNode: (node: TreeNodeData | null) => void;
+    isSelected: boolean;
 }
 
 export default function TableNode({
@@ -56,7 +57,8 @@ export default function TableNode({
     onFocusButtonClick,
     isHovered,
     setHoveredNode,
-    onPopOutClicked
+    onPopOutClicked,
+    isSelected
 }: Readonly<NodeProps>) {
     const [hovered, setHovered] = useState(false)
     const [activeDialog, setActiveDialog] = useState<"above" | "below" | "pos" | null>(null)    
@@ -73,7 +75,7 @@ export default function TableNode({
 
     return (
         <div
-            className={`custom-node${hovered ? ' hovered' : ''}`}
+            className={`custom-node${hovered ? ' hovered' : ''}${isSelected ? ' selected-for-export' : ''}`}
             onMouseLeave={() => {
                 const id = node.id.join('');
                 hoverMap[id] = setTimeout(() => {

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -40,6 +40,8 @@ type TreeProps = {
   hoveredNode?: TreeNodeData | null;
   setHoveredNode: (node: TreeNodeData | null) => void;
   onPopOutClicked: (node: TableNodeData) => void;
+  selectedNodes: TreeNodeData[];
+  onSelectionChange: (nodes: TreeNodeData[]) => void;
 };
 
 export default function Tree({
@@ -69,7 +71,9 @@ export default function Tree({
   hoveredNode,
   setHoveredNode,
   setPanToNodeId,
-  onPopOutClicked
+  onPopOutClicked,
+  selectedNodes,
+  onSelectionChange
 }: Readonly<TreeProps>) {
   type FlextreeLink = {
     source: PositionedTableNodeData, target: PositionedTableNodeData
@@ -171,6 +175,8 @@ export default function Tree({
 
   // Zoom/Pan
   const svgRef = useRef<SVGSVGElement>(null)
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const [selectionBox, setSelectionBox] = useState<{ x: number; y: number; width: number; height: number } | null>(null);
 
   // init Transform-Status
   const centerX = width / 2;
@@ -187,12 +193,61 @@ export default function Tree({
   svg.call(
     d3.zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.2, 3])
-      .filter((event) => event.type !== "dblclick")
+      .filter((event) => event.type !== "dblclick" && !event.ctrlKey && !event.metaKey)
       .on('zoom', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
         setTransform(event.transform)
       })
   );
 }, []);
+
+  const pointerPosition = (event: React.PointerEvent<SVGSVGElement>) => {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    return { x: event.clientX - bounds.left, y: event.clientY - bounds.top };
+  };
+
+  const handleSelectionStart = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (event.button !== 0 || (!event.ctrlKey && !event.metaKey)) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const start = pointerPosition(event);
+    dragStartRef.current = start;
+    setSelectionBox({ ...start, width: 0, height: 0 });
+  };
+
+  const handleSelectionMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    const start = dragStartRef.current;
+    if (!start) return;
+    const current = pointerPosition(event);
+    setSelectionBox({
+      x: Math.min(start.x, current.x),
+      y: Math.min(start.y, current.y),
+      width: Math.abs(current.x - start.x),
+      height: Math.abs(current.y - start.y),
+    });
+  };
+
+  const handleSelectionEnd = (event: React.PointerEvent<SVGSVGElement>) => {
+    const box = selectionBox;
+    dragStartRef.current = null;
+    setSelectionBox(null);
+    if (!box || (box.width < 3 && box.height < 3)) {
+      onSelectionChange([]);
+      return;
+    }
+
+    const selected = nodes
+      .filter(node => {
+        const [centerX, top] = transform.apply([node.x, node.y]);
+        const nodeWidth = Math.max(node.data.width, 60) * transform.k;
+        const nodeHeight = Math.max(node.data.height, 33) * transform.k;
+        const left = centerX - nodeWidth / 2;
+        return left < box.x + box.width && left + nodeWidth > box.x
+          && top < box.y + box.height && top + nodeHeight > box.y;
+      })
+      .map(node => node.data);
+    onSelectionChange(selected);
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  };
 
   const [lastCenteredRootId, setLastCenteredRootId] = useState<number[] | null>(null);
 
@@ -261,6 +316,10 @@ useEffect(() => {
         width={svgWidth}
         height={svgHeight}
         style={{ position: 'absolute', left: 0, top: 0, zIndex: 0 }}
+        onPointerDown={handleSelectionStart}
+        onPointerMove={handleSelectionMove}
+        onPointerUp={handleSelectionEnd}
+        onPointerCancel={handleSelectionEnd}
       >
         <defs>
           <marker
@@ -286,8 +345,8 @@ useEffect(() => {
             ))}
 
           {nodes.map((node: PositionedTableNodeData, i: number) => (
+            <g key={i}>
             <TreeNodeRenderer
-              key={i}
               node={node}
               mode={mode}
               showNodeExecutionTimes={showNodeExecutionTimes}
@@ -312,9 +371,21 @@ useEffect(() => {
               hoveredNode={hoveredNode}
               setHoveredNode={setHoveredNode}
               onPopOutClicked={onPopOutClicked}
+              isSelected={selectedNodes.includes(node.data)}
             />
+            </g>
           ))}
         </g>
+        {selectionBox && (
+          <rect
+            {...selectionBox}
+            fill="rgba(25, 118, 210, 0.12)"
+            stroke="#1976d2"
+            strokeWidth={1.5}
+            strokeDasharray="6 4"
+            pointerEvents="none"
+          />
+        )}
       </svg>
     </div>
   )

--- a/src/components/Tree/TreeNodeRenderer.tsx
+++ b/src/components/Tree/TreeNodeRenderer.tsx
@@ -29,6 +29,7 @@ type TreeNodeRendererProps = {
   setHoveredNode: (node: TreeNodeData | null) => void;
   onPopOutClicked: (node: TableNodeData) => void;
   codingButtonClicked: (node:TreeNodeData) => void;
+  isSelected: boolean;
 };
 
 export default function TreeNodeRenderer({
@@ -55,16 +56,20 @@ export default function TreeNodeRenderer({
   onFocusNode,
   hoveredNode,
   setHoveredNode,
-  onPopOutClicked  
+  onPopOutClicked,
+  isSelected
 }: Readonly<TreeNodeRendererProps>) {
+
+  const renderedWidth = Math.max(node.data.width, 60);
+  const renderedHeight = Math.max(node.data.height, 33);
 
   if (node.data instanceof TableNodeData) {
     return (
       <foreignObject
-        x={node.x - node.data.width / 2}
+        x={node.x - renderedWidth / 2}
         y={node.y}
-        width={node.data.width}
-        height={node.data.height}
+        width={renderedWidth}
+        height={renderedHeight}
         style={{ overflow: 'visible' }}
       >
         <TableNode
@@ -89,6 +94,7 @@ export default function TreeNodeRenderer({
             isHovered={hoveredNode === node.data} 
             setHoveredNode={setHoveredNode}
             onPopOutClicked={onPopOutClicked}
+            isSelected={isSelected}
           />
       </foreignObject>
     )
@@ -96,10 +102,10 @@ export default function TreeNodeRenderer({
   if (node.data instanceof RuleNodeData) {
     return (
       <foreignObject
-        x={node.x - node.data.width / 2}
+        x={node.x - renderedWidth / 2}
         y={node.y}
-        width={node.data.width}
-        height={node.data.height}
+        width={renderedWidth}
+        height={renderedHeight}
         style={{ overflow: 'visible' }}
       >
         <RuleNode
@@ -116,6 +122,7 @@ export default function TreeNodeRenderer({
             onFocusNode={onFocusNode}
             isHovered={hoveredNode === node.data}
             setHoveredNode={setHoveredNode}
+            isSelected={isSelected}
           />
       </foreignObject>
     )


### PR DESCRIPTION
add export tree functionality.

when holding cmd or ctrl and drawing a box, the nodes in the box are selected and if you click export tree button, only selected nodes are exported.

exporting only selected nodes:

drawing a box:

<img width="1713" height="757" alt="Screenshot 2026-06-28 at 10 24 33 AM" src="https://github.com/user-attachments/assets/ea5ed3d2-020b-4f69-b788-8059bb93a7f2" />

showing selected nodes and number of them in the export button:

<img width="1714" height="764" alt="Screenshot 2026-06-28 at 10 24 41 AM" src="https://github.com/user-attachments/assets/28ed583f-b6c3-459e-8b81-b4ff5aaa9acd" />

exporting whole tree if no node is selected:

<img width="1708" height="787" alt="Screenshot 2026-06-28 at 10 25 08 AM" src="https://github.com/user-attachments/assets/ea1f47a5-c8fd-4476-8c11-e0e2b88cfa01" />
